### PR TITLE
Add ability to run a manual step from the CLI and automatically add objects in `calkit run`

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 
 from .core import *
 from . import git

--- a/calkit/cli/__init__.py
+++ b/calkit/cli/__init__.py
@@ -1,0 +1,6 @@
+from .core import *
+
+
+def run() -> None:
+    from .main import app
+    app()

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -1,0 +1,42 @@
+"""Config CLI."""
+
+from __future__ import annotations
+
+import typer
+
+from calkit import config
+from calkit.dvc import configure_remote, set_remote_auth
+
+config_app = typer.Typer(no_args_is_help=True)
+
+
+@config_app.command(name="set")
+def set_config_value(key: str, value: str):
+    try:
+        cfg = config.read()
+        cfg = config.Settings.model_validate(cfg.model_dump() | {key: value})
+        # Kind of a hack for setting the password computed field
+        # Types have been validated above, so this won't hurt to do again
+        setattr(cfg, key, value)
+    except FileNotFoundError:
+        # TODO: This fails if we try to set password before any config has
+        # been written
+        # Username is fine
+        cfg = config.Settings.model_validate({key: value})
+    cfg.write()
+
+
+@config_app.command(name="get")
+def get_config_value(key: str) -> None:
+    cfg = config.read()
+    val = getattr(cfg, key)
+    if val is not None:
+        print(val)
+    else:
+        print()
+
+
+@config_app.command(name="setup-remote")
+def setup_remote():
+    configure_remote()
+    set_remote_auth()

--- a/calkit/cli/core.py
+++ b/calkit/cli/core.py
@@ -1,0 +1,22 @@
+"""Core CLI functionality."""
+
+import os
+import pty
+import subprocess
+
+import typer
+
+
+def print_sep(name: str):
+    width = 66
+    txt_width = len(name) + 2
+    buffer_width = (width - txt_width) // 2
+    buffer = "-" * buffer_width
+    typer.echo(f"{buffer} {name} {buffer}")
+
+
+def run_cmd(cmd: list[str]):
+    if os.name == "nt":
+        subprocess.call(cmd)
+    else:
+        pty.spawn(cmd, lambda fd: os.read(fd, 1024))

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -260,3 +260,32 @@ def run_dvc_repro(
     if downstream is not None:
         args += downstream
     subprocess.call(["dvc", "repro"] + args)
+
+
+@app.command(name="run-manual", help="Execute a manual step.")
+def run_manual(
+    message: Annotated[
+        str,
+        typer.Option(
+            "--message",
+            "-m",
+            help="Message to display as a prompt.",
+        ),
+    ],
+    cmd: Annotated[str, typer.Option("--cmd", help="Command to run.")] = None,
+    show_stdout: Annotated[
+        bool, typer.Option("--show-stdout", help="Show stdout.")
+    ] = False,
+    show_stderr: Annotated[
+        bool, typer.Option("--show-stderr", help="Show stderr.")
+    ] = False,
+) -> None:
+    if cmd is not None:
+        typer.echo(f"Running command: {cmd}")
+        subprocess.Popen(
+            cmd.split(),
+            stderr=subprocess.PIPE if not show_stderr else None,
+            stdout=subprocess.PIPE if not show_stdout else None,
+        )
+    input(message + " (press enter to confirm): ")
+    typer.echo("Done")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -273,6 +273,13 @@ def manual_step(
         ),
     ],
     cmd: Annotated[str, typer.Option("--cmd", help="Command to run.")] = None,
+    shell: Annotated[
+        bool,
+        typer.Option(
+            "--shell",
+            help="Whether or not to execute the command in shell mode.",
+        ),
+    ] = False,
     show_stdout: Annotated[
         bool, typer.Option("--show-stdout", help="Show stdout.")
     ] = False,
@@ -283,9 +290,10 @@ def manual_step(
     if cmd is not None:
         typer.echo(f"Running command: {cmd}")
         subprocess.Popen(
-            cmd.split(),
+            cmd.split() if not shell else cmd,
             stderr=subprocess.PIPE if not show_stderr else None,
             stdout=subprocess.PIPE if not show_stdout else None,
+            shell=shell,
         )
     input(message + " (press enter to confirm): ")
     typer.echo("Done")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -262,8 +262,8 @@ def run_dvc_repro(
     subprocess.call(["dvc", "repro"] + args)
 
 
-@app.command(name="run-manual", help="Execute a manual step.")
-def run_manual(
+@app.command(name="manual-step", help="Execute a manual step.")
+def manual_step(
     message: Annotated[
         str,
         typer.Option(

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1,0 +1,107 @@
+"""CLI for creating new objects."""
+
+from __future__ import annotations
+
+import os
+
+import git
+import typer
+from typing_extensions import Annotated
+
+from calkit.core import ryaml
+
+new_app = typer.Typer(no_args_is_help=True)
+
+
+@new_app.command(name="figure")
+def new_figure(
+    path: str,
+    title: Annotated[str, typer.Option("--title")],
+    description: Annotated[str, typer.Option("--desc")] = None,
+    commit: Annotated[bool, typer.Option("--commit")] = False,
+):
+    """Add a new figure."""
+    if os.path.isfile("calkit.yaml"):
+        with open("calkit.yaml") as f:
+            ck_info = ryaml.load(f)
+    else:
+        ck_info = {}
+    figures = ck_info.get("figures", [])
+    paths = [f.get("path") for f in figures]
+    if path in paths:
+        raise ValueError(f"Figure at path {path} already exists")
+    obj = dict(path=path, title=title)
+    if description is not None:
+        obj["description"] = description
+    figures.append(obj)
+    ck_info["figures"] = figures
+    with open("calkit.yaml", "w") as f:
+        ryaml.dump(ck_info, f)
+    if commit:
+        repo = git.Repo()
+        repo.git.add("calkit.yaml")
+        repo.git.commit(["-m", f"Add figure {path}"])
+
+
+@new_app.command("question")
+def new_question(
+    question: str,
+    commit: Annotated[bool, typer.Option("--commit")] = False,
+):
+    """Add a new question."""
+    if os.path.isfile("calkit.yaml"):
+        with open("calkit.yaml") as f:
+            ck_info = ryaml.load(f)
+    else:
+        ck_info = {}
+    questions = ck_info.get("questions", [])
+    if question in questions:
+        raise ValueError("Question already exists")
+    if not question.endswith("?"):
+        raise ValueError("Questions must end with a question mark")
+    questions.append(question)
+    ck_info["questions"] = questions
+    with open("calkit.yaml", "w") as f:
+        ryaml.dump(ck_info, f)
+    if commit:
+        repo = git.Repo()
+        repo.git.add("calkit.yaml")
+        repo.git.commit(["-m", "Add question"])
+
+
+@new_app.command("notebook")
+def new_notebook(
+    path: Annotated[str, typer.Argument(help="Notebook path (relative)")],
+    title: Annotated[str, typer.Option("--title")],
+    description: Annotated[str, typer.Option("--desc")] = None,
+    commit: Annotated[bool, typer.Option("--commit")] = False,
+):
+    """Add a new notebook."""
+    if os.path.isabs(path):
+        raise ValueError("Path must be relative")
+    if not os.path.isfile(path):
+        raise ValueError("Path is not a file")
+    if not path.endswith(".ipynb"):
+        raise ValueError("Path does not have .ipynb extension")
+    # TODO: Add option to create stages that run `calkit nb clean` and
+    # `calkit nb execute`
+    if os.path.isfile("calkit.yaml"):
+        with open("calkit.yaml") as f:
+            ck_info = ryaml.load(f)
+    else:
+        ck_info = {}
+    notebooks = ck_info.get("notebooks", [])
+    paths = [f.get("path") for f in notebooks]
+    if path in paths:
+        raise ValueError(f"Notebook at path {path} already exists")
+    obj = dict(path=path, title=title)
+    if description is not None:
+        obj["description"] = description
+    notebooks.append(obj)
+    ck_info["notebooks"] = notebooks
+    with open("calkit.yaml", "w") as f:
+        ryaml.dump(ck_info, f)
+    if commit:
+        repo = git.Repo()
+        repo.git.add("calkit.yaml")
+        repo.git.commit(["-m", f"Add notebook {path}"])

--- a/calkit/cli/notebooks.py
+++ b/calkit/cli/notebooks.py
@@ -1,0 +1,76 @@
+"""Notebooks CLI."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import typer
+from typing_extensions import Annotated
+
+notebooks_app = typer.Typer(no_args_is_help=True)
+
+
+@notebooks_app.command("clean")
+def clean_notebook_outputs(path: str):
+    """Clean notebook and place a copy in the cleaned notebooks directory.
+
+    This can be useful to use as a preprocessing DVC stage to use a clean
+    notebook as a dependency for a stage that caches and executed notebook.
+    """
+    if os.path.isabs(path):
+        raise ValueError("Path must be relative")
+    fpath_out = os.path.join(".calkit", "notebooks", "cleaned", path)
+    folder = os.path.dirname(fpath_out)
+    os.makedirs(folder, exist_ok=True)
+    subprocess.call(
+        [
+            "jupyter",
+            "nbconvert",
+            path,
+            "--clear-output",
+            "--to",
+            "notebook",
+            "--output",
+            fpath_out,
+        ]
+    )
+
+
+@notebooks_app.command("execute")
+def execute_notebook(
+    path: str,
+    to: Annotated[
+        str, typer.Option("--to", help="Output format ('html' or 'notebook').")
+    ] = "notebook",
+):
+    """Execute notebook and place a copy in the relevant directory.
+
+    This can be useful to use as a preprocessing DVC stage to use a clean
+    notebook as a dependency for a stage that caches and executed notebook.
+    """
+    if os.path.isabs(path):
+        raise ValueError("Path must be relative")
+    if to == "html":
+        subdir = "html"
+        fname_out = path.removesuffix(".ipynb") + ".html"
+    elif to == "notebook":
+        subdir = "executed"
+        fname_out = path
+    else:
+        raise ValueError(f"Invalid output format: '{to}'")
+    fpath_out = os.path.join(".calkit", "notebooks", subdir, fname_out)
+    folder = os.path.dirname(fpath_out)
+    os.makedirs(folder, exist_ok=True)
+    subprocess.call(
+        [
+            "jupyter",
+            "nbconvert",
+            path,
+            "--execute",
+            "--to",
+            to,
+            "--output",
+            fpath_out,
+        ]
+    )


### PR DESCRIPTION
The use case for this is, e.g., in a DVC pipeline, where one step is manual, it probably produces an output, and we want to block until the user confirms it's done.

Example pipeline:

```yaml
stages:
  do-manual-thing:
    cmd: calkit manual-step -m "Save the output to figures/fig.png" --cmd "matlab"
    outs:
      - figures/fig.png
    deps:
      - scripts/my-interactive-script.m
      - data/my-data.csv
  run-data-collection:
    cmd: calkit manual-step -m "Execute the runs" --cmd "turbinedaq ."
    outs:
      - data/raw
    deps:
      - plan/runs.csv
```

For that last stage, how can we ensure it runs if all of the raw data is not there yet, similar to how TurbineDAQ works? Maybe we always want it to run, but build the logic into `calkit` to examine a chunked step? We could also make it a matrix stage, but then we're executing the command many times.