### PR TITLE
Rename `server` command as `local` to avoid confusion and add installation tips to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ forcing them to work at that lower level of abstraction.
 
 Python must be installed. We recommend
 [Mambaforge](https://conda-forge.org/miniforge/).
-If you're a Windows user amd decide to install Mambaforge or any other
+If you're a Windows user and decide to install Mambaforge or any other
 Conda-based distribution,
 e.g., Anaconda, you'll probably want to ensure that environment is
 [activated by default in Git Bash](https://discuss.codecademy.com/t/setting-up-conda-in-git-bash/534473).

--- a/README.md
+++ b/README.md
@@ -43,7 +43,14 @@ forcing them to work at that lower level of abstraction.
 
 ## Installation
 
-Simply run
+Python must be installed. We recommend
+[Mambaforge](https://conda-forge.org/miniforge/).
+If you're a Windows user amd decide to install Mambaforge or any other
+Conda-based distribution,
+e.g., Anaconda, you'll probably want to ensure that environment is
+[activated by default in Git Bash](https://discuss.codecademy.com/t/setting-up-conda-in-git-bash/534473).
+
+After Python is installed, run
 
 ```sh
 pip install calkit-python

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -298,7 +298,7 @@ def push():
     subprocess.call(["dvc", "push"])
 
 
-@app.command(name="server", help="Run the local server.")
+@app.command(name="local", help="Run the local server to interact over HTTP.")
 def run_server():
     import uvicorn
 


### PR DESCRIPTION
Maybe `local-server` would be even more explicit? It won't be typed often.