### PR TITLE
Add support for Pixi, uv environments and add checking to `calkit runenv`

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.8.5"
+__version__ = "0.9.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import functools
 import hashlib
 import json
 import os
@@ -588,7 +589,9 @@ def run_in_env(
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
         if not no_check:
-            check_conda_env(env_fpath=env["path"], relaxed=relaxed_check)
+            check_conda_env(
+                env_fpath=env["path"], relaxed=relaxed_check, quiet=True
+            )
         # TODO: This only works on *nix-like shells, not Windows command
         # prompts
         # We should detect that
@@ -880,10 +883,21 @@ def check_conda_env(
             "--relaxed", help="Treat conda and pip dependencies as equivalent."
         ),
     ] = False,
+    quiet: Annotated[
+        bool, typer.Option("--quiet", "-q", help="Be quiet.")
+    ] = False,
 ):
+    if quiet:
+
+        def log_func(*args, **kwargs):
+            with open(os.devnull, "w") as f:
+                typer.echo(*args, file=f, **kwargs)
+
+    else:
+        log_func = typer.echo
     calkit.conda.check_env(
         env_fpath=env_fpath,
         output_fpath=output_fpath,
-        log_func=typer.echo,
+        log_func=log_func,
         relaxed=relaxed,
     )

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -589,6 +589,9 @@ def run_in_env(
             conda_env = calkit.ryaml.load(f)
         if not no_check:
             check_conda_env(env_fpath=env["path"], relaxed=relaxed_check)
+        # TODO: This only works on *nix-like shells, not Windows command
+        # prompts
+        # We should detect that
         cmd = [
             "conda",
             "run",

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -608,7 +608,10 @@ def run_in_env(
         except subprocess.CalledProcessError:
             raise_error("Failed to run in Conda environment")
     elif env["kind"] in ["pixi", "uv"]:
-        cmd = [env["kind"], "run"] + cmd
+        env_cmd = []
+        if "name" in env:
+            env_cmd = ["--environment", env["name"]]
+        cmd = [env["kind"], "run"] + env_cmd + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -508,11 +508,11 @@ def run_in_env(
             ),
         ),
     ] = None,
-    no_check: Annotated[
+    check: Annotated[
         bool,
         typer.Option(
-            "--no-check",
-            help="Don't check the environment is valid before running in it.",
+            "--check",
+            help="Check the environment is valid before running in it.",
         ),
     ] = False,
     relaxed_check: Annotated[
@@ -561,7 +561,7 @@ def run_in_env(
     if env["kind"] == "docker":
         if "image" not in env:
             raise_error("Image must be defined for Docker environments")
-        if "path" in env and not no_check:
+        if "path" in env and check:
             check_docker_env(
                 tag=env["image"],
                 fpath=env["path"],
@@ -596,7 +596,7 @@ def run_in_env(
     elif env["kind"] == "conda":
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
-        if not no_check:
+        if check:
             check_conda_env(
                 env_fpath=env["path"], relaxed=relaxed_check, quiet=True
             )
@@ -628,7 +628,7 @@ def run_in_env(
         path = env["path"]
         shell_cmd = " ".join(cmd)
         # Check environment
-        if not no_check:
+        if check:
             if not os.path.isdir(prefix):
                 if verbose:
                     typer.echo(f"Creating uv-venv at {prefix}")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -387,7 +387,10 @@ def run_dvc_repro(
         args += ["--pipeline", pipeline]
     if downstream is not None:
         args += downstream
-    subprocess.check_call(["dvc", "repro"] + args)
+    try:
+        subprocess.check_call(["dvc", "repro"] + args)
+    except subprocess.CalledProcessError:
+        raise_error("DVC pipeline failed")
     # Now parse stage metadata for calkit objects
     if not os.path.isfile("dvc.yaml"):
         raise_error("No dvc.yaml file found")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -546,6 +546,8 @@ def run_in_env(
         env_name = default_env_name
     if env_name is None:
         raise_error("Environment must be specified if there are multiple")
+    if env_name not in envs:
+        raise_error(f"Environment '{env_name}' does not exist")
     env = envs[env_name]
     if wdir is not None:
         cwd = os.path.abspath(wdir)

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -618,6 +618,8 @@ def run_in_env(
         # Check environment
         if not no_check:
             if not os.path.isdir(prefix):
+                if verbose:
+                    typer.echo(f"Creating uv-venv at {prefix}")
                 try:
                     subprocess.check_call(["uv", "venv", prefix], cwd=wdir)
                 except subprocess.CalledProcessError:
@@ -631,6 +633,8 @@ def run_in_env(
                 "&& deactivate"
             )
             try:
+                if verbose:
+                    typer.echo(f"Running command: {check_cmd}")
                 subprocess.check_output(check_cmd, shell=True, cwd=wdir)
             except subprocess.CalledProcessError:
                 raise_error("Failed to check uv-venv")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -559,7 +559,14 @@ def run_in_env(
     shell = env.get("shell", "sh")
     platform = env.get("platform")
     if env["kind"] == "docker":
-        # TODO: Check Docker image if there's a path property
+        if "image" not in env:
+            raise_error("Image must be defined for Docker environments")
+        if "path" in env and not no_check:
+            check_docker_env(
+                tag=env["image"],
+                fpath=env["path"],
+                platform=env.get("platform"),
+            )
         shell_cmd = " ".join(cmd)
         docker_cmd = [
             "docker",
@@ -684,7 +691,7 @@ def check_call(
     name="build-docker",
     help="Build Docker image if missing or different from lock file.",
 )
-def build_docker(
+def check_docker_env(
     tag: Annotated[str, typer.Argument(help="Image tag.")],
     fpath: Annotated[
         str, typer.Option("-i", "--input", help="Path to input Dockerfile.")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -579,7 +579,10 @@ def run_in_env(
         ]
         if verbose:
             typer.echo(f"Running command: {docker_cmd}")
-        subprocess.check_call(docker_cmd, cwd=wdir)
+        try:
+            subprocess.check_call(docker_cmd, cwd=wdir)
+        except subprocess.CalledProcessError:
+            raise_error("Failed to run in Docker environment")
     elif env["kind"] == "conda":
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
@@ -588,12 +591,18 @@ def run_in_env(
         cmd = ["conda", "run", "-n", conda_env["name"]] + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
-        subprocess.check_call(cmd, cwd=wdir)
+        try:
+            subprocess.check_call(cmd, cwd=wdir)
+        except subprocess.CalledProcessError:
+            raise_error("Failed to run in Conda environment")
     elif env["kind"] == "pixi":
         cmd = ["pixi", "run"] + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
-        subprocess.check_call(cmd, cwd=wdir)
+        try:
+            subprocess.check_call(cmd, cwd=wdir)
+        except subprocess.CalledProcessError:
+            raise_error("Failed to run in Pixi environment")
     else:
         raise_error("Environment kind not supported")
 

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -599,14 +599,14 @@ def run_in_env(
             subprocess.check_call(cmd, cwd=wdir)
         except subprocess.CalledProcessError:
             raise_error("Failed to run in Conda environment")
-    elif env["kind"] == "pixi":
-        cmd = ["pixi", "run"] + cmd
+    elif env["kind"] in ["pixi", "uv"]:
+        cmd = [env["kind"], "run"] + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:
             subprocess.check_call(cmd, cwd=wdir)
         except subprocess.CalledProcessError:
-            raise_error("Failed to run in Pixi environment")
+            raise_error(f"Failed to run in {env['kind']} environment")
     else:
         raise_error("Environment kind not supported")
 

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -508,11 +508,11 @@ def run_in_env(
             ),
         ),
     ] = None,
-    check: Annotated[
+    no_check: Annotated[
         bool,
         typer.Option(
-            "--check",
-            help="Check the environment is valid before running in it.",
+            "--no-check",
+            help="Don't check the environment is valid before running in it.",
         ),
     ] = False,
     relaxed_check: Annotated[
@@ -561,7 +561,7 @@ def run_in_env(
     if env["kind"] == "docker":
         if "image" not in env:
             raise_error("Image must be defined for Docker environments")
-        if "path" in env and check:
+        if "path" in env and not no_check:
             check_docker_env(
                 tag=env["image"],
                 fpath=env["path"],
@@ -596,7 +596,7 @@ def run_in_env(
     elif env["kind"] == "conda":
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
-        if check:
+        if not no_check:
             check_conda_env(
                 env_fpath=env["path"], relaxed=relaxed_check, quiet=True
             )
@@ -628,7 +628,7 @@ def run_in_env(
         path = env["path"]
         shell_cmd = " ".join(cmd)
         # Check environment
-        if check:
+        if not no_check:
             if not os.path.isdir(prefix):
                 if verbose:
                     typer.echo(f"Creating uv-venv at {prefix}")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -617,6 +617,11 @@ def run_in_env(
         shell_cmd = " ".join(cmd)
         # Check environment
         if not no_check:
+            if not os.path.isdir(prefix):
+                try:
+                    subprocess.check_call(["uv", "venv", prefix], cwd=wdir)
+                except subprocess.CalledProcessError:
+                    raise_error(f"Failed to create uv-venv at {prefix}")
             fname, ext = os.path.splitext(path)
             lock_fpath = fname + "-lock" + ext
             check_cmd = (
@@ -626,7 +631,7 @@ def run_in_env(
                 "&& deactivate"
             )
             try:
-                subprocess.check_output(check_cmd, shell=True)
+                subprocess.check_output(check_cmd, shell=True, cwd=wdir)
             except subprocess.CalledProcessError:
                 raise_error("Failed to check uv-venv")
         # Now run the command
@@ -634,7 +639,7 @@ def run_in_env(
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:
-            subprocess.check_call(cmd, shell=True)
+            subprocess.check_call(cmd, shell=True, cwd=wdir)
         except subprocess.CalledProcessError:
             raise_error("Failed to run in uv-venv")
     else:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -584,11 +584,20 @@ def run_in_env(
         except subprocess.CalledProcessError:
             raise_error("Failed to run in Docker environment")
     elif env["kind"] == "conda":
+        shell_cmd = " ".join(cmd)
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
         if not no_check:
             check_conda_env(env_fpath=env["path"], relaxed=relaxed_check)
-        cmd = ["conda", "run", "-n", conda_env["name"]] + cmd
+        cmd = [
+            "conda",
+            "run",
+            "-n",
+            conda_env["name"],
+            "/bin/sh",
+            "-c",
+            f"{shell_cmd}",
+        ]
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -504,6 +504,20 @@ def run_in_env(
             ),
         ),
     ] = None,
+    no_check: Annotated[
+        bool,
+        typer.Option(
+            "--no-check",
+            help="Don't check the environment is valid before running in it.",
+        ),
+    ] = False,
+    relaxed_check: Annotated[
+        bool,
+        typer.Option(
+            "--relaxed",
+            help="Check the environment in a relaxed way, if applicable.",
+        ),
+    ] = False,
     verbose: Annotated[
         bool, typer.Option("--verbose", "-v", help="Print verbose output.")
     ] = False,
@@ -564,7 +578,14 @@ def run_in_env(
     elif env["kind"] == "conda":
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
+        if not no_check:
+            check_conda_env(env_fpath=env["path"], relaxed=relaxed_check)
         cmd = ["conda", "run", "-n", conda_env["name"]] + cmd
+        if verbose:
+            typer.echo(f"Running command: {cmd}")
+        subprocess.check_call(cmd, cwd=wdir)
+    elif env["kind"] == "pixi":
+        cmd = ["pixi", "run"] + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
         subprocess.check_call(cmd, cwd=wdir)

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -888,11 +888,7 @@ def check_conda_env(
     ] = False,
 ):
     if quiet:
-
-        def log_func(*args, **kwargs):
-            with open(os.devnull, "w") as f:
-                typer.echo(*args, file=f, **kwargs)
-
+        log_func = functools.partial(typer.echo, file=open(os.devnull, "w"))
     else:
         log_func = typer.echo
     calkit.conda.check_env(

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -627,7 +627,7 @@ def run_in_env(
             fname, ext = os.path.splitext(path)
             lock_fpath = fname + "-lock" + ext
             check_cmd = (
-                f". {prefix}/bin/activate "
+                f"source {prefix}/bin/activate "
                 f"&& uv pip install -q -r {path} "
                 f"&& uv pip freeze > {lock_fpath} "
                 "&& deactivate"
@@ -639,7 +639,7 @@ def run_in_env(
             except subprocess.CalledProcessError:
                 raise_error("Failed to check uv-venv")
         # Now run the command
-        cmd = f". {prefix}/bin/activate && {shell_cmd} && deactivate"
+        cmd = f"source {prefix}/bin/activate && {shell_cmd} && deactivate"
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -585,25 +585,13 @@ def run_in_env(
         except subprocess.CalledProcessError:
             raise_error("Failed to run in Docker environment")
     elif env["kind"] == "conda":
-        shell_cmd = " ".join(cmd)
         with open(env["path"]) as f:
             conda_env = calkit.ryaml.load(f)
         if not no_check:
             check_conda_env(
                 env_fpath=env["path"], relaxed=relaxed_check, quiet=True
             )
-        # TODO: This only works on *nix-like shells, not Windows command
-        # prompts
-        # We should detect that
-        cmd = [
-            "conda",
-            "run",
-            "-n",
-            conda_env["name"],
-            "/bin/sh",
-            "-c",
-            f"{shell_cmd}",
-        ]
+        cmd = ["conda", "run", "-n", conda_env["name"]] + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -608,6 +608,7 @@ def run_in_env(
         except subprocess.CalledProcessError:
             raise_error(f"Failed to run in {env['kind']} environment")
     elif env["kind"] == "uv-venv":
+        # TODO: This doesn't work on Windows
         if "prefix" not in env:
             raise_error("uv-venv environments require a prefix")
         if "path" not in env:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -559,6 +559,7 @@ def run_in_env(
     shell = env.get("shell", "sh")
     platform = env.get("platform")
     if env["kind"] == "docker":
+        # TODO: Check Docker image if there's a path property
         shell_cmd = " ".join(cmd)
         docker_cmd = [
             "docker",

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -627,7 +627,7 @@ def run_in_env(
             fname, ext = os.path.splitext(path)
             lock_fpath = fname + "-lock" + ext
             check_cmd = (
-                f"source {prefix}/bin/activate "
+                f". {prefix}/bin/activate "
                 f"&& uv pip install -q -r {path} "
                 f"&& uv pip freeze > {lock_fpath} "
                 "&& deactivate"
@@ -639,7 +639,7 @@ def run_in_env(
             except subprocess.CalledProcessError:
                 raise_error("Failed to check uv-venv")
         # Now run the command
-        cmd = f"source {prefix}/bin/activate && {shell_cmd} && deactivate"
+        cmd = f". {prefix}/bin/activate && {shell_cmd} && deactivate"
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:


### PR DESCRIPTION
## TODO

- [ ] ~~Check should be opt-in rather than opt-out?~~ -- no, it's a good sane default to always check envs are good to go, and saves us a stage
- [x] Check Docker images as well
- [x] Add `uv` env support or save for later PR? (#105)

Resolves #119 
Resolves #105 