### PR TITLE
Add functionality to evaluate arithmetic expressions and linear calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dev.ipynb
 *.pyc
 .DS_Store
+.vscode

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -10,3 +10,5 @@ from . import models
 from . import office
 from . import templates
 from . import conda
+from . import calc
+from . import check

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.1"
+__version__ = "0.11.0"
 
 from .core import *
 from . import git

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -60,7 +60,7 @@ class Calculation(BaseModel):
             out_name = self.output
         template = self.output_template
         if template is None:
-            template = "For inputs "
+            template = "For input "
             for input_name in inputs:
                 template += input_name + "={" + input_name + "}, "
             template += "the output is "

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -29,7 +29,7 @@ class Output(BaseModel):
 
 
 class Calculation(BaseModel):
-    kind: Literal["formula"]
+    kind: str
     params: dict = {}
     name: str | None = None
     description: str | None = None

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -21,6 +21,7 @@ class Output(BaseModel):
     name: str
     description: str | None = None
     dtype: Literal["int", "float", "str"] = "float"
+    template: str | None = None
 
 
 class Calculation(BaseModel):
@@ -30,7 +31,6 @@ class Calculation(BaseModel):
     description: str | None = None
     inputs: dict[str, Input] | list[str]
     output: Output | str
-    output_template: str | None = None
     # TODO: Enforce that we don't have any inputs with the same name as the output
 
     def check_inputs(self, **inputs) -> dict:
@@ -66,9 +66,10 @@ class Calculation(BaseModel):
         res = self.evaluate(**inputs)
         if isinstance(self.output, Output):
             out_name = self.output.name
+            template = self.output.template
         else:
             out_name = self.output
-        template = self.output_template
+            template = None
         if template is None:
             template = "For input "
             for input_name in inputs:

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -168,10 +168,13 @@ class HttpRequest(Calculation):
 
 class XGBoostModelParams(BaseModel):
     path: str
+    type: Literal["classifier", "regressor"]
 
 
 class XGBoostModel(Calculation):
     """Make predictions with an XGBoost model saved as JSON.
+
+    This is currently just a prototype and should not be expected to work.
 
     One input, ``data``, should be defined to be passed to the model's
     ``predict`` method.
@@ -187,7 +190,11 @@ class XGBoostModel(Calculation):
 
         # Convert model path to something that can be loaded if running on the
         # Calkit Cloud
-        model = xgboost.Booster(model_file=self.params.path)
+        types = {
+            "classifier": xgboost.XGBClassifier,
+            "regressor": xgboost.XGBRegressor,
+        }
+        model = types[self.params.type]().load_model(self.params.path)
         return model.predict(**inputs)
 
 

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -1,0 +1,62 @@
+"""Functionality for calculations."""
+
+from typing import Literal
+
+import arithmetic_eval
+from pydantic import BaseModel
+
+
+class Input(BaseModel):
+    dtype: Literal["int", "float"] = "float"
+    min: int | float | None = None
+    max: int | float | None = None
+
+
+class Output(BaseModel):
+    dtype: Literal["int", "float"] = "float"
+
+
+class Calculation(BaseModel):
+    kind: Literal["formula"]
+    title: str | None = None
+    description: str | None = None
+    inputs: dict[str, Input] | list[str]
+    outputs: dict[str, Output] | list[str]
+
+    def check_inputs(self, **inputs) -> None:
+        """Check that the supplied inputs match those declared."""
+        for k in self.inputs:
+            if k not in inputs:
+                raise ValueError(f"Missing input {k}")
+        for k, v in inputs.items():
+            if k not in self.inputs:
+                raise ValueError(f"{k} is not in declared inputs")
+            if isinstance(self.inputs, dict):
+                input_def = self.inputs[k]
+                if input_def.min is not None and v < input_def.min:
+                    raise ValueError(f"Input value {k} = {v} it too small")
+                if input_def.max is not None and v > input_def.max:
+                    raise ValueError(f"Input value {k} = {v} is too large")
+
+    def evaluate(self, **inputs) -> dict:
+        raise NotImplementedError
+
+
+class Formula(Calculation):
+    kind: str = "formula"
+    formula: str
+
+    def evaluate(self, **inputs):
+        self.check_inputs(**inputs)
+        return arithmetic_eval.evaluate(self.formula, inputs)
+
+
+def parse(data: dict) -> Calculation:
+    if isinstance(data, BaseModel):
+        data = data.model_dump()
+    kinds = {"formula": Formula}
+    return kinds[data["kind"]].model_validate(data)
+
+
+def evaluate(calc_def: dict | Calculation, **inputs) -> dict:
+    return parse(calc_def).evaluate(**inputs)

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -175,11 +175,6 @@ class LookupTable(Calculation):
     kind: str = "lookup-table"
     params: LookupTableParams
 
-    def check_inputs(self, **inputs) -> dict:
-        if len(inputs) > 1:
-            raise ValueError("Only one input can be provided")
-        return super().check_inputs(**inputs)
-
 
 class HttpRequestParams(BaseModel):
     url: str

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -31,7 +31,15 @@ class Calculation(BaseModel):
     description: str | None = None
     inputs: list[Input] | list[str]
     output: Output | str
-    # TODO: Enforce that we don't have any inputs with the same name as the output
+
+    @model_validator(mode="after")
+    def validate_model(self) -> Calculation:
+        input_names = self.input_names
+        if self.output_name in input_names:
+            raise ValueError("Output name must not overlap with input names")
+        if len(set(input_names)) != len(input_names):
+            raise ValueError("Input names must be unique")
+        return self
 
     @property
     def input_names(self) -> list[str]:
@@ -52,6 +60,12 @@ class Calculation(BaseModel):
             else:
                 res[i.name] = i
         return res
+
+    @property
+    def output_name(self) -> str:
+        if isinstance(self.output, Output):
+            return self.output.name
+        return self.output
 
     def check_inputs(self, **inputs) -> dict:
         """Check that the supplied inputs match those declared and do type

--- a/calkit/calc.py
+++ b/calkit/calc.py
@@ -145,6 +145,31 @@ class HttpRequest(Calculation):
             return resp.text
 
 
+class XGBoostModelParams(BaseModel):
+    path: str
+
+
+class XGBoostModel(Calculation):
+    """Make predictions with an XGBoost model saved as JSON.
+
+    One input, ``data``, should be defined to be passed to the model's
+    ``predict`` method.
+    """
+
+    kind: str = "xgboost"
+    params: XGBoostModelParams
+
+    def evaluate(self, **inputs):
+        super().check_inputs(**inputs)
+        # Load model from JSON
+        import xgboost
+
+        # Convert model path to something that can be loaded if running on the
+        # Calkit Cloud
+        model = xgboost.Booster(model_file=self.params.path)
+        return model.predict(**inputs)
+
+
 def parse(data: dict) -> Calculation:
     if isinstance(data, BaseModel):
         data = data.model_dump()

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -978,3 +978,36 @@ def check_conda_env(
         log_func=log_func,
         relaxed=relaxed,
     )
+
+
+@app.command(name="calc")
+def run_calculation(
+    name: Annotated[str, typer.Argument(help="Calculation name.")],
+    inputs: Annotated[
+        list[str],
+        typer.Option(
+            "--input", "-i", help="Inputs defined like x=1 (with no spaces.)"
+        ),
+    ] = [],
+    no_formatting: Annotated[
+        bool,
+        typer.Option(
+            "--no-format", help="Do not format output before printing"
+        ),
+    ] = False,
+):
+    """Run a project's calculation."""
+    ck_info = calkit.load_calkit_info()
+    calcs = ck_info.get("calculations", {})
+    if name not in calcs:
+        raise_error(f"Calculation '{name}' not defined in calkit.yaml")
+    calc = calkit.calc.parse(calcs[name])
+    # Parse inputs
+    parsed_inputs = {}
+    for i in inputs:
+        iname, ival = i.split("=")
+        parsed_inputs[iname] = ival
+    if no_formatting:
+        typer.echo(calc.evaluate(**parsed_inputs))
+    else:
+        typer.echo(calc.evaluate_and_format(**parsed_inputs))

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -1001,13 +1001,19 @@ def run_calculation(
     calcs = ck_info.get("calculations", {})
     if name not in calcs:
         raise_error(f"Calculation '{name}' not defined in calkit.yaml")
-    calc = calkit.calc.parse(calcs[name])
+    try:
+        calc = calkit.calc.parse(calcs[name])
+    except Exception as e:
+        raise_error(f"Invalid calculation: {e}")
     # Parse inputs
     parsed_inputs = {}
     for i in inputs:
         iname, ival = i.split("=")
         parsed_inputs[iname] = ival
-    if no_formatting:
-        typer.echo(calc.evaluate(**parsed_inputs))
-    else:
-        typer.echo(calc.evaluate_and_format(**parsed_inputs))
+    try:
+        if no_formatting:
+            typer.echo(calc.evaluate(**parsed_inputs))
+        else:
+            typer.echo(calc.evaluate_and_format(**parsed_inputs))
+    except Exception as e:
+        raise_error(f"Calculation failed: {e}")

--- a/calkit/tests/test_calc.py
+++ b/calkit/tests/test_calc.py
@@ -9,8 +9,9 @@ def test_formula():
     calc = calkit.calc.Formula(
         params=dict(formula="0.2151 * x + y**2"),
         inputs=["x", "y"],
-        output=calkit.calc.Output(name="z", description="The value"),
-        output_template="The value is {z:.1f}.",
+        output=calkit.calc.Output(
+            name="z", description="The value", template="The value is {z:.1f}."
+        ),
     )
     assert calc.evaluate(x=10.2, y=0.1) == 2.20402
     res = calkit.calc.evaluate_and_format(calc, x=5, y=1)

--- a/calkit/tests/test_calc.py
+++ b/calkit/tests/test_calc.py
@@ -20,6 +20,26 @@ def test_formula():
         calc.evaluate(x=5)
     with pytest.raises(ValueError):
         calc.evaluate(z=5)
+    with pytest.raises(ValueError):
+        calc = calkit.calc.Formula(
+            params=dict(formula="0.2151 * x + y**2"),
+            inputs=["x", "x"],
+            output=calkit.calc.Output(
+                name="z",
+                description="The value",
+                template="The value is {z:.1f}.",
+            ),
+        )
+    with pytest.raises(ValueError):
+        calc = calkit.calc.Formula(
+            params=dict(formula="0.2151 * x + y**2"),
+            inputs=["x", "y"],
+            output=calkit.calc.Output(
+                name="x",
+                description="The value",
+                template="The value is {z:.1f}.",
+            ),
+        )
 
 
 def test_lookuptable():

--- a/calkit/tests/test_calc.py
+++ b/calkit/tests/test_calc.py
@@ -1,0 +1,48 @@
+"""Tests for ``calkit.calc``."""
+
+import pytest
+
+import calkit
+
+
+def test_formula():
+    calc = calkit.calc.Formula(
+        params=dict(formula="0.2151 * x + y**2"),
+        inputs=["x", "y"],
+        output=calkit.calc.Output(name="z", description="The value"),
+        output_template="The value is {z:.1f}.",
+    )
+    assert calc.evaluate(x=10.2, y=0.1) == 2.20402
+    res = calkit.calc.evaluate_and_format(calc, x=5, y=1)
+    assert res == "The value is 2.1."
+    with pytest.raises(ValueError):
+        calc.evaluate(x=5)
+    with pytest.raises(ValueError):
+        calc.evaluate(z=5)
+
+
+def test_lookuptable():
+    calc = calkit.calc.LookupTable(
+        inputs=["x"],
+        output="something",
+        params=calkit.calc.LookupTableParams(
+            x_values=[1, 2, 3], y_values=[4, 5, 6]
+        ),
+    )
+    # TODO: Implement this
+
+
+def test_linear():
+    calc = calkit.calc.Linear(
+        params=calkit.calc.LinearParams(
+            coeffs=dict(input_voltage=1.1), offset=0.01
+        ),
+        inputs=["input_voltage"],
+        output="load_lbf",
+    )
+    res = calc.evaluate(input_voltage=1.534)
+    assert round(res, ndigits=3) == 1.697
+    res2 = calkit.calc.evaluate_and_format(calc, input_voltage=-0.5)
+    assert (
+        res2 == "For input input_voltage=-0.5, the output is load_lbf=-0.54."
+    )

--- a/calkit/tests/test_calc.py
+++ b/calkit/tests/test_calc.py
@@ -38,7 +38,7 @@ def test_linear():
         params=calkit.calc.LinearParams(
             coeffs=dict(input_voltage=1.1), offset=0.01
         ),
-        inputs=["input_voltage"],
+        inputs=[{"name": "input_voltage", "dtype": "float"}],
         output="load_lbf",
     )
     res = calc.evaluate(input_voltage=1.534)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 dependencies = [
+  "arithmeval",
   "docx2pdf",
   "dvc",
   "eval-type-backport; python_version < '3.10'",


### PR DESCRIPTION
Towards #34 

Ultimate usage will be on the web front end. Users can ship a calculation with their project, e.g., one that computes predictions from things discovered in their paper, and we can show that interactively on the homepage.

## TODO

- [x] Add CLI for `new` and `runcalc`
- [x] Think about the future usage for different calculation types, e.g., ML models, Docker CLI/REST, marimo?
- [x] Params should be nested so we can parse any Calculation kind from YAML?
- [x] Tests
- [x] Only allow a single output