### PR TITLE
Allow creating new projects from templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,15 +66,42 @@ Then run
 calkit config set token ${YOUR_TOKEN_HERE}
 ```
 
-Then, inside a project repo you'd like to connect to the cloud, run
+## Quickstart
+
+After installing Calkit and setting your token as described above,
+run something like:
 
 ```sh
-calkit config remote
+calkit new project my-calkit-project \
+    --title "My Calkit project" \
+    --description "Your description here." \
+    --template calkit/example-basic \ # Optional
+    --cloud \ # Optional
+    --public # Optional
 ```
 
-This will setup the Calkit DVC remote, such that commands like `dvc push` will
-allow you to push versions of your data or pipeline outputs to the cloud
-for safe storage and sharing with your collaborators.
+This will create a new project from the `calkit/example-basic` template,
+creating it in the cloud and cloning to `my-calkit-project`.
+You should now be able to run:
+
+```sh
+cd my-calkit-project
+calkit run
+```
+
+This will reproduce the project's pipeline.
+Next, you can start adding stages to the pipeline,
+modifying the Python environments and scripts,
+and editing the paper.
+All will be kept in sync with the `calkit run` command.
+
+To back up all of your work, execute:
+
+```sh
+calkit save -am "Run pipeline"
+```
+
+This will commit and push to both GitHub and the Calkit Cloud.
 
 ## Tutorials
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ calkit new project calkit-project-1 \
     --title "My first Calkit project" \
     --template calkit/example-basic \
     --cloud \
-    --public # Optional
+    --public
 ```
 
 This will create a new project from the

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ calkit new project my-calkit-project \
     --public # Optional
 ```
 
-This will create a new project from the `calkit/example-basic` template,
+This will create a new project from the
+[`calkit/example-basic`](https://calkit.io/calkit/example-basic)
+template,
 creating it in the cloud and cloning to `my-calkit-project`.
 You should now be able to run:
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ management interface and a DVC remote for easily storing all versions of your
 data/code/figures/publications, interacting with your collaborators,
 reusing others' research artifacts, etc.
 
-After signing up, visit the [settings](https://calkit.io/settings) page
-and create a token.
+After signing up, visit the
+[settings](https://calkit.io/settings?tab=tokens)
+page and create a token for use with the API.
 Then run
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -69,27 +69,24 @@ calkit config set token ${YOUR_TOKEN_HERE}
 
 ## Quickstart
 
-After installing Calkit and setting your token as described above,
-run something like:
+After installing Calkit and setting your token as described above, run:
 
 ```sh
-calkit new project my-calkit-project \
-    --title "My Calkit project" \
-    --description "Your description here." \
-    --template calkit/example-basic \ # Optional
-    --cloud \ # Optional
+calkit new project calkit-project-1 \
+    --title "My first Calkit project" \
+    --template calkit/example-basic \
+    --cloud \
     --public # Optional
 ```
 
 This will create a new project from the
-[`calkit/example-basic`](https://calkit.io/calkit/example-basic)
+[`calkit/example-basic`](https://github.com/calkit/example-basic)
 template,
-creating it in the cloud (as long as `--cloud` was specified)
-and cloning to `my-calkit-project`.
+creating it in the cloud and cloning to `calkit-project-1`.
 You should now be able to run:
 
 ```sh
-cd my-calkit-project
+cd calkit-project-1
 calkit run
 ```
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ calkit new project my-calkit-project \
 This will create a new project from the
 [`calkit/example-basic`](https://calkit.io/calkit/example-basic)
 template,
-creating it in the cloud and cloning to `my-calkit-project`.
+creating it in the cloud (as long as `--cloud` was specified)
+and cloning to `my-calkit-project`.
 You should now be able to run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ calkit config set token ${YOUR_TOKEN_HERE}
 Then, inside a project repo you'd like to connect to the cloud, run
 
 ```sh
-calkit config setup-remote
+calkit config remote
 ```
 
 This will setup the Calkit DVC remote, such that commands like `dvc push` will

--- a/calkit/check.py
+++ b/calkit/check.py
@@ -68,7 +68,7 @@ class ReproCheck(BaseModel):
         if not self.n_dvc_remotes:
             return (
                 "No DVC remotes have been defined. "
-                "Run `calkit config setup-remote` or `dvc remote add` next."
+                "Run `calkit config remote` or `dvc remote add` next."
             )
         if not self.has_pipeline:
             return (

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -42,7 +42,8 @@ def get_config_value(key: str) -> None:
         print()
 
 
-@config_app.command(name="setup-remote")
+@config_app.command(name="setup-remote", help="Alias for 'remote'.")
+@config_app.command(name="remote")
 def setup_remote():
     """Setup the Calkit cloud as the default DVC remote and store a token in
     the local config.
@@ -56,7 +57,8 @@ def setup_remote():
         raise_error("Current directory is not a Git repository")
 
 
-@config_app.command(name="setup-remote-auth")
+@config_app.command(name="setup-remote-auth", help="Alias for 'remote-auth'.")
+@config_app.command(name="remote-auth")
 def setup_remote_auth():
     """Store a Calkit cloud token in the local DVC config for all Calkit
     remotes.

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -61,7 +61,7 @@ def new_project(
             "--git-url",
             help=(
                 "Git repo URL. "
-                "Usually https://github.com/{your_name}/{project_name}"
+                "Usually https://github.com/{your_name}/{project_name}."
             ),
         ),
     ] = None,

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -45,10 +45,7 @@ def new_project(
         bool,
         typer.Option(
             "--cloud",
-            help=(
-                "Whether or not to create this project in the cloud "
-                "(Calkit and GitHub.)"
-            ),
+            help=("Create this project in the cloud (Calkit and GitHub.)"),
         ),
     ] = False,
     public: Annotated[

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -211,7 +211,7 @@ def new_project(
             )
             warn(
                 "You will need to manually run `git remote add origin` "
-                "and `calkit config setup-remote`"
+                "and `calkit config remote`"
             )
             subprocess.call(
                 ["dvc", "remote", "remove", "calkit", "-q"], cwd=abs_path

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -139,7 +139,11 @@ def new_project(
         except Exception as e:
             raise_error(f"Posting new project to cloud failed: {e}")
         # Now clone here and that's about
-        subprocess.run(["calkit", "clone", resp["git_repo_url"], abs_path])
+        subprocess.run(["git", "clone", resp["git_repo_url"], abs_path])
+        try:
+            calkit.dvc.set_remote_auth(wdir=abs_path)
+        except Exception:
+            warn("Failed to setup Calkit DVC remote auth")
         prj = calkit.git.detect_project_name(path=abs_path)
         add_msg = f"\n\nYou can view your project at https://calkit.io/{prj}"
         typer.echo(success_message + add_msg)

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -69,6 +69,7 @@ def new_project(
         str,
         typer.Option(
             "--template",
+            "-t",
             help=(
                 "Template from which to derive the project, e.g., "
                 "'calkit/example-basic'."
@@ -788,6 +789,7 @@ def new_publication(
         str,
         typer.Option(
             "--template",
+            "-t",
             help=(
                 "Template with which to create the source files. "
                 "Should be in the format {type}/{name}."

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -11,9 +11,12 @@ def detect_project_name(path: str = None) -> str:
     """Read the project owner and name from the remote."""
     ck_info = calkit.load_calkit_info(wdir=path)
     name = ck_info.get("name")
+    owner = ck_info.get("owner")
     url = git.Repo(path=path).remote().url
     from_url = url.split("github.com")[-1][1:].removesuffix(".git")
     owner_name, project_name = from_url.split("/")
     if name is None:
         name = project_name
-    return f"{owner_name}/{name}"
+    if owner is None:
+        owner = owner_name
+    return f"{owner}/{name}"


### PR DESCRIPTION
Resolves #60 

Example:

```sh
calkit new project --cloud --title "Test 7" --template calkit/example-basic test-7 --public
```

Cloud integration depends on changes in https://github.com/calkit/calkit-cloud/pull/245.

## TODO

- [ ] `--from` instead of `--template` for consistency? We use `--template` for `new publication` though.