### PR TITLE
Allow more flexible version specifiers in conda.check_env

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.0"
+__version__ = "0.11.1"
 
 from .core import *
 from . import git

--- a/calkit/tests/test_conda.py
+++ b/calkit/tests/test_conda.py
@@ -5,7 +5,25 @@ import uuid
 
 import pytest
 
-from calkit.conda import check_env
+from calkit.conda import _check_list, _check_single, check_env
+
+
+def test_check_single():
+    assert _check_single("python=3.12", "python=3.12.18", conda=True)
+    assert _check_single("python=3", "python=3.12.18", conda=True)
+    assert _check_single("python=3.12.18", "python=3.12.18", conda=True)
+    assert _check_single("python>=3.12,<3.13", "python==3.12.18", conda=False)
+
+
+def test_check_list():
+    installed = ["python=3.12.1", "numpy=1.0.11"]
+    assert _check_list("python=3", installed, conda=True)
+    assert _check_list("numpy", installed, conda=True)
+    assert not _check_list("pandas", installed, conda=True)
+    installed = ["python==3.12.1", "numpy==1.0.11"]
+    assert _check_list("python>=3", installed, conda=False)
+    assert _check_list("numpy", installed, conda=False)
+    assert not _check_list("pandas", installed, conda=False)
 
 
 def delete_env(name: str):
@@ -123,4 +141,23 @@ def test_check_env(tmp_dir, env_name):
         ]
     )
     res = check_env(relaxed=True)
+    assert not res.env_needs_rebuild
+    # Make sure we can handle other ways of specifying versions
+    subprocess.check_call(
+        [
+            "calkit",
+            "new",
+            "conda-env",
+            "--overwrite",
+            "-n",
+            env_name,
+            "python=3.12",
+            "--pip",
+            "numpy>=1",
+        ]
+    )
+    res = check_env()
+    assert res.env_needs_rebuild
+    res = check_env()
+    assert not res.env_needs_export
     assert not res.env_needs_rebuild


### PR DESCRIPTION
Resolves #147 