### PR TITLE
Alias `xenv` to `runenv` and `xproc` to `runproc`

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.11.3"
+__version__ = "0.12.0"
 
 from .core import *
 from . import git

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.0"
+__version__ = "0.11.4"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -519,7 +519,12 @@ def manual_step(
 
 @app.command(
     name="runenv",
-    help="Run a command in an environment.",
+    help="Execute a command in an environment (alias for 'xenv').",
+    context_settings={"ignore_unknown_options": True},
+)
+@app.command(
+    name="xenv",
+    help="Execute a command in an environment.",
     context_settings={"ignore_unknown_options": True},
 )
 def run_in_env(
@@ -802,7 +807,8 @@ def check_docker_env(
         json.dump(inspect, f, indent=4)
 
 
-@app.command(name="runproc", help="Run or execute a procedure.")
+@app.command(name="runproc", help="Execute a procedure (alias for 'xproc').")
+@app.command(name="xproc", help="Execute a procedure.")
 def run_procedure(
     name: Annotated[str, typer.Argument(help="The name of the procedure.")],
     no_commit: Annotated[

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -910,7 +910,7 @@ def new_publication(
             f"-pdf {template_obj.target}"
         )
         if env_name is not None:
-            cmd = f'calkit runenv -n {env_name} "{cmd}"'
+            cmd = f'calkit xenv -n {env_name} "{cmd}"'
         target_dep = os.path.join(path, template_obj.target)
         dvc_cmd = [
             "dvc",

--- a/calkit/magics.py
+++ b/calkit/magics.py
@@ -264,7 +264,7 @@ class Calkit(Magics):
                 cmd += ["-o", _posix_path(path)]
         stage_cmd = f'python "{_posix_path(script_fpath)}"'
         if args.env:
-            runenv = "calkit runenv"
+            runenv = "calkit xenv"
             if isinstance(args.env, str):
                 runenv += f" -n {args.env}"
             stage_cmd = runenv + " -- " + stage_cmd

--- a/calkit/magics.py
+++ b/calkit/magics.py
@@ -264,10 +264,10 @@ class Calkit(Magics):
                 cmd += ["-o", _posix_path(path)]
         stage_cmd = f'python "{_posix_path(script_fpath)}"'
         if args.env:
-            runenv = "calkit xenv"
+            xenv = "calkit xenv"
             if isinstance(args.env, str):
-                runenv += f" -n {args.env}"
-            stage_cmd = runenv + " -- " + stage_cmd
+                xenv += f" -n {args.env}"
+            stage_cmd = xenv + " -- " + stage_cmd
         cmd.append(stage_cmd)
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -72,6 +72,7 @@ class Environment(BaseModel):
         "uv",
         "pixi",
         "uv-venv",
+        "renv",
     ]
     path: str | None = None
     description: str | None = None
@@ -90,6 +91,11 @@ class DockerEnvironment(Environment):
     layers: list[str] | None = None
     shell: Literal["bash", "sh"] = "sh"
     platform: str | None = None
+
+
+class REnvironment(Environment):
+    kind: Literal["renv"]
+    prefix: str
 
 
 class Software(BaseModel):

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -23,7 +23,7 @@ def test_run_in_env(tmp_dir):
     )
     subprocess.check_call("calkit run", shell=True)
     out = (
-        subprocess.check_output("calkit runenv echo sup", shell=True)
+        subprocess.check_output("calkit xenv echo sup", shell=True)
         .decode()
         .strip()
     )
@@ -50,7 +50,7 @@ def test_run_in_env(tmp_dir):
     subprocess.check_call("calkit run", shell=True)
     with pytest.raises(subprocess.CalledProcessError):
         out = (
-            subprocess.check_output("calkit runenv echo sup", shell=True)
+            subprocess.check_output("calkit xenv echo sup", shell=True)
             .decode()
             .strip()
         )
@@ -58,7 +58,7 @@ def test_run_in_env(tmp_dir):
         subprocess.check_output(
             [
                 "calkit",
-                "runenv",
+                "xenv",
                 "-n",
                 "env2",
                 "python",
@@ -80,7 +80,7 @@ def test_run_in_env(tmp_dir):
     )
     out = (
         subprocess.check_output(
-            "calkit runenv -n py3.10 python --version", shell=True
+            "calkit xenv -n py3.10 python --version", shell=True
         )
         .decode()
         .strip()
@@ -96,7 +96,7 @@ def test_run_in_env(tmp_dir):
     out = subprocess.check_output(
         [
             "calkit",
-            "runenv",
+            "xenv",
             "-n",
             "uv1",
             "--",

--- a/calkit/tests/cli/test_new.py
+++ b/calkit/tests/cli/test_new.py
@@ -166,7 +166,7 @@ def test_new_publication(tmp_dir):
     print(dvc_pipeline)
     stage = dvc_pipeline["stages"]["build-latex-article"]
     assert stage["cmd"] == (
-        "calkit runenv -n my-latex-env "
+        "calkit xenv -n my-latex-env "
         '"cd my-paper && latexmk -interaction=nonstopmode -pdf paper.tex"'
     )
 

--- a/docs/tutorials/conda-envs.md
+++ b/docs/tutorials/conda-envs.md
@@ -79,7 +79,7 @@ calkit new conda-env \
 ```
 
 Calkit will create an environment definition in `calkit.yaml`,
-which enables running a command in this environment with
-`calkit runenv -n my-project-py311 my-command-here`.
+which enables executing a command in this environment with
+`calkit xenv -n my-project-py311 my-command-here`.
 That call will automatically create or update the Conda environment on the fly
 as needed and export a lock file describing the actual environment.

--- a/docs/tutorials/procedures.md
+++ b/docs/tutorials/procedures.md
@@ -54,7 +54,7 @@ Here we use an `_include` key to reference the other file to help keep
 
 ## Executing
 
-If we run `calkit runproc my-important-procedure` from the command line,
+If we run `calkit xproc my-important-procedure` from the command line,
 our procedure will start.
 We will be prompted to perform the first step and press enter to confirm.
 
@@ -93,7 +93,7 @@ has been run, and if the plot need to be remade.
 ```yaml
 stages:
   run-proc:
-    cmd: calkit runproc my-important-procedure
+    cmd: calkit xproc my-important-procedure
     outs:
       - .calkit/procedure-runs/my-important-procedure:
           cache: false # Track this in Git, not DVC


### PR DESCRIPTION
Want to avoid confusion with `run` and use commands like `uvx`.

Resolves #159.