### PR TITLE
Add compatibility with Python's built-in `venv` module

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -719,7 +719,7 @@ def run_in_env(
         try:
             subprocess.check_call(cmd, shell=True, cwd=wdir)
         except subprocess.CalledProcessError:
-            raise_error("Failed to run in uv-venv")
+            raise_error(f"Failed to run in {kind}")
     else:
         raise_error("Environment kind not supported")
 

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -694,6 +694,10 @@ def run_in_env(
             ["uv", "venv"] if kind == "uv-venv" else ["python", "-m", "venv"]
         )
         pip_cmd = "pip" if kind == "venv" else "uv pip"
+        pip_install_args = "-q"
+        if "python" in env and kind == "uv-venv":
+            create_cmd += ["--python", env["python"]]
+            pip_install_args += f" --python {env['python']}"
         # Check environment
         if not no_check:
             if not os.path.isdir(prefix):
@@ -711,7 +715,7 @@ def run_in_env(
                 activate_cmd = f". {prefix}/bin/activate"
             check_cmd = (
                 f"{activate_cmd} "
-                f"&& {pip_cmd} install -q -r {path} "
+                f"&& {pip_cmd} install {pip_install_args} -r {path} "
                 f"&& {pip_cmd} freeze > {lock_fpath} "
                 "&& deactivate"
             )
@@ -719,7 +723,10 @@ def run_in_env(
                 if verbose:
                     typer.echo(f"Running command: {check_cmd}")
                 subprocess.check_output(
-                    check_cmd, shell=True, cwd=wdir, stderr=subprocess.STDOUT
+                    check_cmd,
+                    shell=True,
+                    cwd=wdir,
+                    stderr=subprocess.STDOUT if not verbose else None,
                 )
             except subprocess.CalledProcessError:
                 raise_error(f"Failed to check {kind}")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -678,7 +678,18 @@ def run_in_env(
             raise_error("venv environments require a path")
         prefix = env["prefix"]
         path = env["path"]
-        shell_cmd = " ".join(cmd)
+        # Any parts of the raw command with whitespace in them need to be
+        # quoted
+        quoted_cmd = []
+        for part in cmd:
+            if " " in part:
+                part = f'"{part}"'
+            quoted_cmd.append(part)
+        shell_cmd = " ".join(quoted_cmd)
+        if verbose:
+            typer.echo(f"Raw command: {cmd}")
+            typer.echo(f"Quoted command: {quoted_cmd}")
+            typer.echo(f"Shell command: {shell_cmd}")
         create_cmd = (
             ["uv", "venv"] if kind == "uv-venv" else ["python", "-m", "venv"]
         )

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1162,6 +1162,11 @@ def new_venv(
                     f"Environment '{env_name}' already exists with "
                     f"prefix '{prefix}'"
                 )
+    # Put a gitignore file in the env dir if one doesn't exist
+    if not os.path.isfile(os.path.join(prefix, ".gitignore")):
+        os.makedirs(prefix, exist_ok=True)
+        with open(os.path.join(prefix, ".gitignore"), "w") as f:
+            f.write("*\n")
     packages_txt = "\n".join(packages)
     # Write environment to path
     with open(path, "w") as f:

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1051,6 +1051,9 @@ def new_uv_venv(
     prefix: Annotated[
         str, typer.Option("--prefix", help="Prefix for environment location.")
     ] = ".venv",
+    python_version: Annotated[
+        str, typer.Option("--python", "-p", help="Python version.")
+    ] = None,
     description: Annotated[
         str, typer.Option("--description", help="Description.")
     ] = None,
@@ -1097,6 +1100,8 @@ def new_uv_venv(
     repo.git.add(path)
     typer.echo("Adding environment to calkit.yaml")
     env = dict(path=path, kind="uv-venv", prefix=prefix)
+    if python_version is not None:
+        env["python"] = python_version
     if description is not None:
         env["description"] = description
     envs[name] = env

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1167,11 +1167,6 @@ def new_venv(
                     f"Environment '{env_name}' already exists with "
                     f"prefix '{prefix}'"
                 )
-    # Put a gitignore file in the env dir if one doesn't exist
-    if not os.path.isfile(os.path.join(prefix, ".gitignore")):
-        os.makedirs(prefix, exist_ok=True)
-        with open(os.path.join(prefix, ".gitignore"), "w") as f:
-            f.write("*\n")
     packages_txt = "\n".join(packages)
     # Write environment to path
     with open(path, "w") as f:

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -465,9 +465,7 @@ def new_docker_env(
     ] = "Dockerfile",
     stage: Annotated[
         str,
-        typer.Option(
-            "--stage", help="DVC pipeline stage name, deprecated."
-        ),
+        typer.Option("--stage", help="DVC pipeline stage name, deprecated."),
     ] = None,
     layers: Annotated[
         list[str],
@@ -1084,6 +1082,14 @@ def new_uv_venv(
             f"Environment with name {name} already exists "
             "(use -f to overwrite)"
         )
+    # Check prefixes
+    if not overwrite:
+        for env_name, env in envs.items():
+            if env.get("prefix") == prefix:
+                raise_error(
+                    f"Environment '{env_name}' already exists with "
+                    f"prefix '{prefix}'"
+                )
     packages_txt = "\n".join(packages)
     # Write environment to path
     with open(path, "w") as f:
@@ -1100,3 +1106,75 @@ def new_uv_venv(
     repo.git.add("calkit.yaml")
     if not no_commit and repo.git.diff("--staged"):
         repo.git.commit(["-m", f"Add uv venv {name}"])
+
+
+@new_app.command("venv")
+def new_venv(
+    packages: Annotated[
+        list[str],
+        typer.Argument(help="Packages to include in the environment."),
+    ],
+    name: Annotated[
+        str, typer.Option("--name", "-n", help="Environment name.")
+    ],
+    path: Annotated[
+        str, typer.Option("--path", help="Path for requirements file.")
+    ] = "requirements.txt",
+    prefix: Annotated[
+        str, typer.Option("--prefix", help="Prefix for environment location.")
+    ] = ".venv",
+    description: Annotated[
+        str, typer.Option("--description", help="Description.")
+    ] = None,
+    overwrite: Annotated[
+        bool,
+        typer.Option(
+            "--overwrite",
+            "-f",
+            help="Overwrite any existing environment with this name.",
+        ),
+    ] = False,
+    no_commit: Annotated[
+        bool, typer.Option("--no-commit", help="Do not commit changes.")
+    ] = False,
+):
+    """Create a new uv virtual environment."""
+    if os.path.isfile(path) and not overwrite:
+        raise_error("Output path already exists (use -f to overwrite)")
+    repo = git.Repo()
+    # Add environment to Calkit info
+    ck_info = calkit.load_calkit_info()
+    # If environments is a list instead of a dict, reformulate it
+    envs = ck_info.get("environments", {})
+    if isinstance(envs, list):
+        typer.echo("Converting environments from list to dict")
+        envs = {env.pop("name"): env for env in envs}
+    if name in envs and not overwrite:
+        raise_error(
+            f"Environment with name {name} already exists "
+            "(use -f to overwrite)"
+        )
+    # Check prefixes
+    if not overwrite:
+        for env_name, env in envs.items():
+            if env.get("prefix") == prefix:
+                raise_error(
+                    f"Environment '{env_name}' already exists with "
+                    f"prefix '{prefix}'"
+                )
+    packages_txt = "\n".join(packages)
+    # Write environment to path
+    with open(path, "w") as f:
+        f.write(packages_txt)
+    repo.git.add(path)
+    typer.echo("Adding environment to calkit.yaml")
+    env = dict(path=path, kind="venv", prefix=prefix)
+    if description is not None:
+        env["description"] = description
+    envs[name] = env
+    ck_info["environments"] = envs
+    with open("calkit.yaml", "w") as f:
+        ryaml.dump(ck_info, f)
+    repo.git.add("calkit.yaml")
+    if not no_commit and repo.git.diff("--staged"):
+        repo.git.commit(["-m", f"Add venv {name}"])

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -71,6 +71,7 @@ class Environment(BaseModel):
         "remote-ssh",
         "uv",
         "pixi",
+        "venv",
         "uv-venv",
         "renv",
     ]
@@ -78,6 +79,11 @@ class Environment(BaseModel):
     description: str | None = None
     stage: str | None = None
     default: bool | None = None
+
+
+class VenvEnvironment(Environment):
+    kind: Literal["venv"]
+    prefix: str
 
 
 class UvVenvEnvironment(Environment):
@@ -222,7 +228,8 @@ class ProjectInfo(BaseModel):
     publications: list[Publication] = []
     references: list[ReferenceCollection] = []
     environments: dict[
-        str, Environment | DockerEnvironment | UvVenvEnvironment
+        str,
+        Environment | DockerEnvironment | VenvEnvironment | UvVenvEnvironment,
     ] = {}
     software: list[Software] = []
     notebooks: list[Notebook] = []

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -89,23 +89,74 @@ def test_run_in_env(tmp_dir):
     ck_info = calkit.load_calkit_info()
     env = ck_info["environments"]["py3.10"]
     assert env.get("path") is None
+
+
+def test_run_in_venv(tmp_dir):
+    subprocess.check_call("git init", shell=True)
+    subprocess.check_call("dvc init", shell=True)
     # Test uv venv
     subprocess.check_call(
-        ["calkit", "new", "uv-venv", "-n", "uv1", "polars==1.18.0"]
-    )
-    out = subprocess.check_output(
         [
             "calkit",
-            "xenv",
+            "new",
+            "uv-venv",
             "-n",
             "uv1",
-            "--",
-            "python",
-            "-c",
-            "'import polars; print(polars.__version__)'",
+            "--python",
+            "3.13",
+            "--no-commit",
+            "polars==1.18.0",
         ]
-    ).decode().strip()
+    )
+    out = (
+        subprocess.check_output(
+            [
+                "calkit",
+                "xenv",
+                "-n",
+                "uv1",
+                "--",
+                "python",
+                "-c",
+                "import polars; print(polars.__version__)",
+            ]
+        )
+        .decode()
+        .strip()
+    )
     assert out == "1.18.0"
+    # Test regular venvs
+    subprocess.check_call(
+        [
+            "calkit",
+            "new",
+            "venv",
+            "-n",
+            "venv1",
+            "--prefix",
+            ".venv1",
+            "--path",
+            "reqs2.txt",
+            "polars==1.17.0",
+        ]
+    )
+    out = (
+        subprocess.check_output(
+            [
+                "calkit",
+                "xenv",
+                "-n",
+                "venv1",
+                "--",
+                "python",
+                "-c",
+                "import polars; print(polars.__version__)",
+            ]
+        )
+        .decode()
+        .strip()
+    )
+    assert out == "1.17.0"
 
 
 def test_check_call():


### PR DESCRIPTION
Example:

```sh
calkit new venv --name my-venv "pandas>=2.0"
```

```sh
calkit xenv -n my-venv -- python -c "import pandas; print(pandas.__version__)"
```