### PR TITLE
Add ability to create a new pixi env from the command line

### DIFF
--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1143,7 +1143,7 @@ def new_venv(
         bool, typer.Option("--no-commit", help="Do not commit changes.")
     ] = False,
 ):
-    """Create a new uv virtual environment."""
+    """Create a new Python virtual environment with venv."""
     if os.path.isfile(path) and not overwrite:
         raise_error("Output path already exists (use -f to overwrite)")
     repo = git.Repo()

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -91,6 +91,11 @@ class UvVenvEnvironment(Environment):
     prefix: str
 
 
+class PixiEnvironment(Environment):
+    kind: Literal["pixi"]
+    name: str | None = None
+
+
 class DockerEnvironment(Environment):
     kind: Literal["docker"]
     image: str

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -157,6 +157,37 @@ def test_run_in_venv(tmp_dir):
         .strip()
     )
     assert out == "1.17.0"
+    # Test pixi envs
+    subprocess.check_call(
+        [
+            "calkit",
+            "new",
+            "pixi-env",
+            "-n",
+            "my-pixi",
+            "pandas=2.0.0",
+        ]
+    )
+    ck_info = calkit.load_calkit_info(as_pydantic=True)
+    envs = ck_info.environments
+    env = envs["my-pixi"]
+    out = (
+        subprocess.check_output(
+            [
+                "calkit",
+                "xenv",
+                "-n",
+                "my-pixi",
+                "--",
+                "python",
+                "-c",
+                "import pandas; print(pandas.__version__)",
+            ]
+        )
+        .decode()
+        .strip()
+    )
+    assert out == "2.0.0"
 
 
 def test_check_call():


### PR DESCRIPTION
Resolves #144 

```sh
calkit new pixi-env -n pixi1 pandas polars numpy
```

```sh
calkit xenv -n pixi1 -- which python
```