### PR TITLE
Don't delete pixi.toml file and use --force to create pixi env

### DIFF
--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1223,8 +1223,6 @@ def new_pixi_env(
             f"Environment with name {name} already exists "
             "(use -f to overwrite)"
         )
-    if os.path.isfile("pixi.toml") and overwrite:
-        os.remove("pixi.toml")
     # Create the environment now
     if not os.path.isfile("pixi.toml"):
         subprocess.run(
@@ -1255,6 +1253,7 @@ def new_pixi_env(
             name,
             "--feature",
             name,
+            "--force",
         ]
     )
     typer.echo("Adding environment to calkit.yaml")

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1230,6 +1230,8 @@ def new_pixi_env(
                 "pixi",
                 "init",
                 ".",
+                "--format",
+                "pixi",
                 "--platform",
                 "win-64",
                 "--platform",


### PR DESCRIPTION
This was a bit of a bug, where if you had two pixi envs and used `--overwrite` to create a new one, the others would be deleted.