### PR TITLE
Add ability to declare environmental variables and config items as project dependencies

### DIFF
--- a/calkit/cli/core.py
+++ b/calkit/cli/core.py
@@ -24,9 +24,9 @@ def run_cmd(cmd: list[str]):
 
 
 def raise_error(txt: str):
-    typer.echo(typer.style("Error: " + txt, fg="red"), err=txt)
+    typer.echo(typer.style("Error: " + str(txt), fg="red"), err=txt)
     raise typer.Exit(1)
 
 
 def warn(txt: str):
-    typer.echo(typer.style("Warning: " + txt, fg="yellow"))
+    typer.echo(typer.style("Warning: " + str(txt), fg="yellow"))

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -231,16 +231,20 @@ def make_readme_content(
     return txt
 
 
-def check_dep_exists(exe_name: str) -> bool:
+def check_dep_exists(
+    name: str, kind: Literal["app", "env-var"] = "app"
+) -> bool:
     """Check that a dependency exists.
 
     TODO: Add version checking.
     """
-    if exe_name == "calkit":
+    if kind == "env-var":
+        return name in os.environ
+    if name == "calkit":
         return True
-    cmd = [exe_name]
+    cmd = [name]
     # Executables with non-conventional CLIs
-    if exe_name == "matlab":
+    if name == "matlab":
         cmd.append("-help")
     else:
         # Fall back to simply calling ``--version``
@@ -275,10 +279,12 @@ def check_system_deps(wdir: str | None = None) -> None:
             if len(keys) != 1:
                 raise ValueError(f"Malformed dependency: {dep}")
             dep_name = keys[0]
+            dep_kind = dep[dep_name].get("kind", "app")
         else:
             dep_name = re.split("[=<>]", dep)[0]
-        if not check_dep_exists(dep_name):
-            raise ValueError(f"{dep_name} not found")
+            dep_kind = "app"
+        if not check_dep_exists(dep_name, dep_kind):
+            raise ValueError(f"{dep_kind} '{dep_name}' not found")
 
 
 def project_and_path_from_path(path: str) -> tuple:

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -232,7 +232,7 @@ def make_readme_content(
 
 
 def check_dep_exists(
-    name: str, kind: Literal["app", "env-var"] = "app"
+    name: str, kind: Literal["app", "env-var", "calkit-config"] = "app"
 ) -> bool:
     """Check that a dependency exists.
 
@@ -240,6 +240,11 @@ def check_dep_exists(
     """
     if kind == "env-var":
         return name in os.environ
+    if kind == "calkit-config":
+        import calkit.config
+
+        cfg = calkit.config.read()
+        return getattr(cfg, name, None) is not None
     if name == "calkit":
         return True
     cmd = [name]


### PR DESCRIPTION
Towards #122 

## TODO

- [ ] Add secrets handling?
- [ ] Allow defining these on a per-environment basis? -- we could do similar checks in `xenv`
- [ ] `calkit check deps` as a way to see if a project is ready to run?