### PR TITLE
Improve UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dev.ipynb
 .DS_Store
 .vscode
 site
+.env

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.14.5"
+__version__ = "0.15.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Literal, Annotated
+import subprocess
+from typing import Annotated
 
 import typer
 
-import calkit
 from calkit.check import check_reproducibility
+from calkit.cli import raise_error
 
 check_app = typer.Typer(no_args_is_help=True)
 
@@ -16,8 +17,32 @@ check_app = typer.Typer(no_args_is_help=True)
 def check_repro(
     wdir: Annotated[
         str, typer.Option("--wdir", help="Project working directory.")
-    ] = "."
+    ] = ".",
 ):
     """Check the reproducibility of a project."""
     res = check_reproducibility(wdir=wdir, log_func=typer.echo)
     typer.echo(res.to_pretty().encode("utf-8", errors="replace"))
+
+
+@check_app.command(name="call")
+def check_call(
+    cmd: Annotated[str, typer.Argument(help="Command to check.")],
+    if_error: Annotated[
+        str,
+        typer.Option(
+            "--if-error", help="Command to run if there is an error."
+        ),
+    ],
+):
+    """Check that a command succeeds and run an alternate if not."""
+    try:
+        subprocess.check_call(cmd, shell=True)
+        typer.echo("Command succeeded")
+    except subprocess.CalledProcessError:
+        typer.echo("Command failed")
+        try:
+            typer.echo("Attempting fallback call")
+            subprocess.check_call(if_error, shell=True)
+            typer.echo("Fallback call succeeded")
+        except subprocess.CalledProcessError:
+            raise_error("Fallback call failed")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import time
 
+import dotenv
 import git
 import typer
 from typing_extensions import Annotated, Optional
@@ -57,8 +58,8 @@ def _to_shell_cmd(cmd: list[str]) -> str:
     quoted_cmd = []
     for part in cmd:
         if " " in part or '"' in part or "'" in part:
-            part = part.replace('"', r'\"')
-            quoted_cmd.append(f"\"{part}\"")
+            part = part.replace('"', r"\"")
+            quoted_cmd.append(f'"{part}"')
         else:
             quoted_cmd.append(part)
     return " ".join(quoted_cmd)
@@ -1079,3 +1080,18 @@ def run_calculation(
             typer.echo(calc.evaluate_and_format(**parsed_inputs))
     except Exception as e:
         raise_error(f"Calculation failed: {e}")
+
+
+@app.command(name="set-env-var")
+def set_env_var(
+    name: Annotated[str, typer.Argument(help="Name of the variable.")],
+    value: Annotated[str, typer.Argument(help="Value of the variable.")],
+):
+    """Set an environmental variable for the project in its '.env' file."""
+    # Ensure that .env is ignored by git
+    repo = git.Repo()
+    if not repo.ignored(".env"):
+        typer.echo("Adding .env to .gitignore")
+        with open(".gitignore", "a") as f:
+            f.write("\n.env\n")
+    dotenv.set_key(dotenv_path=".env", key_to_set=name, value_to_set=value)

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -945,7 +945,7 @@ def run_procedure(
     # Check to make sure the working tree is clean, so we know we ran the
     # committed version of the procedure
     git_status = git_repo.git.status()
-    if not "working tree clean" in git_status:
+    if "working tree clean" not in git_status:
         raise_error(
             f"Cannot execute procedures unless repo is clean:\n\n{git_status}"
         )

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -423,7 +423,7 @@ def run_local_server():
     name="run",
     add_help_option=False,
 )
-def run_dvc_repro(
+def run(
     targets: Optional[list[str]] = typer.Argument(default=None),
     help: Annotated[bool, typer.Option("-h", "--help")] = False,
     quiet: Annotated[bool, typer.Option("-q", "--quiet")] = False,
@@ -453,9 +453,7 @@ def run_dvc_repro(
     no_commit: Annotated[bool, typer.Option("--no-commit")] = False,
     no_run_cache: Annotated[bool, typer.Option("--no-run-cache")] = False,
 ):
-    """Run DVC pipeline and parse Calkit objects from metadata after checking
-    system dependencies.
-    """
+    """Check dependencies, run DVC pipeline, and update Calkit objects."""
     dotenv.load_dotenv(dotenv_path=".env", verbose=verbose)
     # First check any system-level dependencies exist
     typer.echo("Checking system-level dependencies")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -414,6 +414,7 @@ def run_dvc_repro(
     """Run DVC pipeline and parse Calkit objects from metadata after checking
     system dependencies.
     """
+    dotenv.load_dotenv(dotenv_path=".env", verbose=verbose)
     # First check any system-level dependencies exist
     typer.echo("Checking system-level dependencies")
     try:
@@ -597,6 +598,7 @@ def run_in_env(
         bool, typer.Option("--verbose", "-v", help="Print verbose output.")
     ] = False,
 ):
+    dotenv.load_dotenv(dotenv_path=".env", verbose=verbose)
     ck_info = calkit.load_calkit_info(process_includes="environments")
     envs = ck_info.get("environments", {})
     if not envs:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -318,9 +318,7 @@ def save(
         dvc_repo = dvc.repo.Repo()
         dvc_status = dvc_repo.data_status()
         for dvc_uncommitted in dvc_status["uncommitted"].get("modified", []):
-            typer.echo(
-                f"Adding {dvc_uncommitted} to DVC"
-            )
+            typer.echo(f"Adding {dvc_uncommitted} to DVC")
             dvc_repo.commit(dvc_uncommitted, force=True)
         repo = git.Repo()
         untracked_git_files = repo.untracked_files
@@ -796,35 +794,6 @@ def run_in_env(
             raise_error(f"Failed to run in {kind}")
     else:
         raise_error("Environment kind not supported")
-
-
-@app.command(
-    name="check-call",
-    help=(
-        "Check that a call to a command succeeds and run another command "
-        "if there is an error."
-    ),
-)
-def check_call(
-    cmd: Annotated[str, typer.Argument(help="Command to check.")],
-    if_error: Annotated[
-        str,
-        typer.Option(
-            "--if-error", help="Command to run if there is an error."
-        ),
-    ],
-):
-    try:
-        subprocess.check_call(cmd, shell=True)
-        typer.echo("Command succeeded")
-    except subprocess.CalledProcessError:
-        typer.echo("Command failed")
-        try:
-            typer.echo("Attempting fallback call")
-            subprocess.check_call(if_error, shell=True)
-            typer.echo("Fallback call succeeded")
-        except subprocess.CalledProcessError:
-            raise_error("Fallback call failed")
 
 
 @app.command(

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -359,7 +359,7 @@ def save(
 
 @app.command(name="pull")
 def pull(
-    no_check_auth: Annotated[bool, typer.Option("--no-check-auth")] = False
+    no_check_auth: Annotated[bool, typer.Option("--no-check-auth")] = False,
 ):
     """Pull with both Git and DVC."""
     typer.echo("Git pulling")
@@ -383,7 +383,7 @@ def pull(
 
 @app.command(name="push")
 def push(
-    no_check_auth: Annotated[bool, typer.Option("--no-check-auth")] = False
+    no_check_auth: Annotated[bool, typer.Option("--no-check-auth")] = False,
 ):
     """Push with both Git and DVC."""
     typer.echo("Pushing to Git remote")

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Literal
 
 from pydantic import BaseModel

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -21,7 +21,7 @@ class _ImportedFromUrl(BaseModel):
 class _CalkitObject(BaseModel):
     path: str
     title: str
-    description: str
+    description: str | None = None
     stage: str | None = None
 
 
@@ -201,6 +201,14 @@ class ModelRelease(Release):
     path: str
 
 
+class ShowcaseFigure(BaseModel):
+    figure: str
+
+
+class ShowcaseText(BaseModel):
+    text: str
+
+
 class ProjectInfo(BaseModel):
     """All of the project's information or metadata, written to the
     ``calkit.yaml`` file.
@@ -243,3 +251,4 @@ class ProjectInfo(BaseModel):
         str,
         ProjectRelease | PublicationRelease | DatasetRelease | ModelRelease,
     ] = {}
+    showcase: list[ShowcaseFigure | ShowcaseText] | None = None

--- a/calkit/ops.py
+++ b/calkit/ops.py
@@ -1,0 +1,45 @@
+"""Ops functionality.
+
+An op is a process that runs outside the pipeline, e.g., for continuous data
+collection, a task run on a schedule, or a fixed number of iterations.
+"""
+
+from typing import Literal
+from pydantic import BaseModel
+
+
+class Op(BaseModel):
+    kind = Literal[
+        "single-shot",
+        "continuous",
+        "fixed-iterations",
+        "scheduled",
+        "event-driven",
+    ]
+    cmd: str
+
+
+class ContinuousOp(Op):
+    """Run continuously."""
+
+    pass
+
+
+class ScheduledOp(Op):
+    kind = Literal["scheduled"]
+    schedule: str  # TODO: Be more specific about validation
+
+
+class FixedIterationsOp(Op):
+    kind = Literal["fixed-iterations"]
+    n_iterations: int
+
+
+def run(op: Op):
+    """Run an op."""
+    pass
+
+
+def start(ops: list[Op]):
+    """Start and monitor a list of ops."""
+    pass

--- a/calkit/server.py
+++ b/calkit/server.py
@@ -454,7 +454,7 @@ def discard_changes(owner_name: str, project_name: str) -> Message:
             subprocess.check_call(
                 ["dvc", "checkout", path, "--force"], cwd=project.wdir
             )
-    except dvc.config.ConfigError as e:
+    except dvc.config.ConfigError:
         pass
     return Message(message="Changes successfully discarded")
 

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -193,28 +193,6 @@ def test_run_in_venv(tmp_dir):
     assert out == "2.0.0"
 
 
-def test_check_call():
-    out = (
-        subprocess.check_output(
-            ["calkit", "check-call", "echo sup", "--if-error", "echo yo"]
-        )
-        .decode()
-        .strip()
-        .split("\n")
-    )
-    assert "sup" in out
-    assert "yo" not in out
-    out = (
-        subprocess.check_output(
-            ["calkit", "check-call", "sup", "--if-error", "echo yo"]
-        )
-        .decode()
-        .strip()
-        .split("\n")
-    )
-    assert "yo" in out
-
-
 def test_to_shell_cmd():
     cmd = ["python", "-c", "import math; print('hello world')"]
     subprocess.check_call(cmd)
@@ -224,12 +202,12 @@ def test_to_shell_cmd():
     cmd = ["echo", "hello world"]
     subprocess.check_call(cmd)
     shell_cmd = _to_shell_cmd(cmd)
-    assert shell_cmd == "echo \"hello world\""
+    assert shell_cmd == 'echo "hello world"'
     subprocess.check_call(shell_cmd, shell=True)
     cmd = ["python", "-c", "print('sup')"]
     shell_cmd = _to_shell_cmd(cmd)
     assert shell_cmd == "python -c \"print('sup')\""
     cmd = ["python", "-c", 'print("hello world")']
     shell_cmd = _to_shell_cmd(cmd)
-    assert shell_cmd == "python -c \"print(\\\"hello world\\\")\""
+    assert shell_cmd == 'python -c "print(\\"hello world\\")"'
     subprocess.check_call(shell_cmd, shell=True)

--- a/calkit/tests/test_check.py
+++ b/calkit/tests/test_check.py
@@ -29,3 +29,25 @@ def test_check_reproducibility(tmp_path):
     res = check_reproducibility()
     assert res.has_readme
     assert res.instructions_in_readme
+
+
+def test_check_call():
+    out = (
+        subprocess.check_output(
+            ["calkit", "check", "call", "echo sup", "--if-error", "echo yo"]
+        )
+        .decode()
+        .strip()
+        .split("\n")
+    )
+    assert "sup" in out
+    assert "yo" not in out
+    out = (
+        subprocess.check_output(
+            ["calkit", "check", "call", "sup", "--if-error", "echo yo"]
+        )
+        .decode()
+        .strip()
+        .split("\n")
+    )
+    assert "yo" in out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "pydantic[email]",
   "pydantic-settings",
   "pyjwt",
+  "python-dotenv>=1",
   "pywin32; platform_system == 'Windows'",
   "requests",
   "typer",
@@ -50,8 +51,8 @@ docs = [
 
 [project.urls]
 Homepage = "https://calkit.org"
-Repository = "https://github.com/calkit/calkit"
 Issues = "https://github.com/calkit/calkit/issues"
+Repository = "https://github.com/calkit/calkit"
 
 [project.scripts]
 calkit = "calkit.cli:run"


### PR DESCRIPTION
- Parse `.env` files before running pipeline or commands in environments -- resolves #122 
- Make `save --all` automatically add or ignore untracked files -- towards #156 
- Started ops model -- towards #90 

## TODO

- [ ] Add unit test for updating `.env` between stages to ensure we could use it for expiring credentials
- [ ] Add ability to add env var as a dependency if `calkit set-env-var` is run
- [ ] Docs for these features
- [ ] `save` should be interactive if `-a` and/or `-m` are missing? Ask what to do with each file, save or ignore?