### PR TITLE
Make version control UX easier

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,5 +27,5 @@ jobs:
           path: .cache
           restore-keys: |
             mkdocs-material-
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-mermaid2-plugin
       - run: mkdocs gh-deploy --force

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.15.0"
+__version__ = "0.16.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -336,6 +336,8 @@ def save(
 
     This is essentially git/dvc add, commit, and push in one step.
     """
+    if not paths and not save_all:
+        raise_error("Paths must be provided if not using --all")
     if paths is not None:
         add(paths, to=to)
     elif save_all:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -287,6 +287,10 @@ def commit(
     ] = False,
 ):
     """Commit a change to the repo."""
+    if message is None:
+        typer.echo("Please provide a message describing the changes.")
+        typer.echo("Example: Update y-label in scripts/plot-data.py")
+        message = typer.prompt("Message")
     cmd = ["git", "commit"]
     if all:
         cmd.append("-a")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -254,7 +254,7 @@ def add(
             elif os.path.splitext(path)[-1] in dvc_extensions:
                 typer.echo(f"Adding {path} to DVC per its extension")
                 subprocess.call(["dvc", "add", path])
-            if calkit.get_size(path) > dvc_size_thresh_bytes:
+            elif calkit.get_size(path) > dvc_size_thresh_bytes:
                 typer.echo(
                     f"Adding {path} to DVC since it's greater than 1 MB"
                 )

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -80,6 +80,18 @@ def main(
         raise typer.Exit()
 
 
+@app.command(name="init")
+def init():
+    """Initialize the current working directory."""
+    raise_error("Not implemented")
+    subprocess.run(["git", "init"])
+    subprocess.run(["dvc", "init"])
+    # Initialize `calkit.yaml`
+    # Initialize `dvc.yaml`
+    # Add a sane .gitignore file
+    # Add a sane LICENSE file?
+
+
 @app.command(name="clone")
 def clone(
     url: Annotated[str, typer.Argument(help="Repo URL.")],

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -376,6 +376,14 @@ def save(
         # Now add changed files
         for changed_file in [d.a_path for d in repo.index.diff(None)]:
             repo.git.add(changed_file)
+    if message is None:
+        typer.echo("No message provided; entering interactive mode")
+        typer.echo("Creating a commit including the following paths:")
+        for path in calkit.git.get_staged_files():
+            typer.echo(f"- {path}")
+        typer.echo("Please provide a message describing the changes.")
+        typer.echo("Example: Add new data to data/raw")
+        message = typer.prompt("Message")
     commit(all=True if paths is None else False, message=message)
     if not no_push:
         push()

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -81,15 +81,26 @@ def main(
 
 
 @app.command(name="init")
-def init():
+def init(
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help="Force reinitializing DVC if already initialized.",
+        ),
+    ] = False,
+):
     """Initialize the current working directory."""
-    raise_error("Not implemented")
     subprocess.run(["git", "init"])
-    subprocess.run(["dvc", "init"])
-    # Initialize `calkit.yaml`
-    # Initialize `dvc.yaml`
-    # Add a sane .gitignore file
-    # Add a sane LICENSE file?
+    dvc_cmd = ["dvc", "init"]
+    if force:
+        dvc_cmd.append("-f")
+    subprocess.run(dvc_cmd)
+    # TODO: Initialize `calkit.yaml`
+    # TODO: Initialize `dvc.yaml`
+    # TODO: Add a sane .gitignore file
+    # TODO: Add a sane LICENSE file?
 
 
 @app.command(name="clone")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -1111,4 +1111,9 @@ def set_env_var(
 @app.command(name="upgrade")
 def upgrade():
     """Upgrade Calkit."""
-    subprocess.check_call(["pip", "install", "--upgrade", "calkit-python"])
+    # See if uv is installed first
+    if calkit.check_dep_exists("uv"):
+        cmd = ["uv", "pip", "install", "--system"]
+    else:
+        cmd = ["pip", "install"]
+    subprocess.run(cmd + ["--upgrade", "calkit-python"])

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -238,10 +238,6 @@ def add(
         ]
         if "." in paths and to is None:
             raise_error("Cannot add '.' with calkit; use git or dvc")
-        if to is None:
-            for path in paths:
-                if os.path.isdir(path):
-                    raise_error("Cannot auto-add directories; use git or dvc")
         for path in paths:
             # Detect if this file should be tracked with Git or DVC
             # First see if it's in Git
@@ -250,25 +246,22 @@ def add(
                     f"Adding {path} to Git since it's already in the repo"
                 )
                 subprocess.call(["git", "add", path])
-                continue
-            if path in dvc_paths:
+            elif path in dvc_paths:
                 typer.echo(
                     f"Adding {path} to DVC since it's already tracked with DVC"
                 )
                 subprocess.call(["dvc", "add", path])
-                continue
-            if os.path.splitext(path)[-1] in dvc_extensions:
+            elif os.path.splitext(path)[-1] in dvc_extensions:
                 typer.echo(f"Adding {path} to DVC per its extension")
                 subprocess.call(["dvc", "add", path])
-                continue
-            if os.path.getsize(path) > dvc_size_thresh_bytes:
+            if calkit.get_size(path) > dvc_size_thresh_bytes:
                 typer.echo(
                     f"Adding {path} to DVC since it's greater than 1 MB"
                 )
                 subprocess.call(["dvc", "add", path])
-                continue
-            typer.echo(f"Adding {path} to Git")
-            subprocess.call(["git", "add", path])
+            else:
+                typer.echo(f"Adding {path} to Git")
+                subprocess.call(["git", "add", path])
     if commit_message is not None:
         subprocess.call(["git", "commit", "-m", commit_message])
     if push_commit:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -1106,3 +1106,9 @@ def set_env_var(
         with open(".gitignore", "a") as f:
             f.write("\n.env\n")
     dotenv.set_key(dotenv_path=".env", key_to_set=name, value_to_set=value)
+
+
+@app.command(name="upgrade")
+def upgrade():
+    """Upgrade Calkit."""
+    subprocess.check_call(["pip", "install", "--upgrade", "calkit-python"])

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -362,3 +362,21 @@ def read_file(path: str, as_bytes: bool = None) -> str | bytes:
     # Project is None, so let's just read a local file
     with open(path, mode="rb" if as_bytes else "r") as f:
         return f.read()
+
+
+def get_size(path: str):
+    """Get the size of a path in bytes.
+
+    This differs from ``os.path.getsize`` in that it is recursive.
+    """
+    if os.path.isfile(path):
+        return os.path.getsize(path)
+    # From https://stackoverflow.com/a/1392549/2284865
+    total_size = 0
+    for dirpath, dirnames, filenames in os.walk(path):
+        for f in filenames:
+            fp = os.path.join(dirpath, f)
+            # skip if it is symbolic link
+            if not os.path.islink(fp):
+                total_size += os.path.getsize(fp)
+    return total_size

--- a/calkit/dvc.py
+++ b/calkit/dvc.py
@@ -6,6 +6,8 @@ import logging
 import os
 import subprocess
 
+import dvc.repo
+
 import calkit
 from calkit.config import get_app_name
 
@@ -102,3 +104,9 @@ def get_remotes(wdir: str = None) -> dict[str, str]:
         name, url = line.split("\t")
         resp[name] = url
     return resp
+
+
+def list_paths(wdir: str = None) -> list[str]:
+    """List paths tracked with DVC."""
+    dvc_repo = dvc.repo.Repo(wdir)
+    return [p.get("path") for p in dvc_repo.ls(".", dvc_only=True)]

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -20,3 +20,13 @@ def detect_project_name(path: str = None) -> str:
     if owner is None:
         owner = owner_name
     return f"{owner}/{name}"
+
+
+def get_staged_files(path: str = None) -> list[str]:
+    repo = git.Repo(path)
+    cmd = ["--staged", "--name-only"]
+    if path is not None:
+        cmd.append(path)
+    diff = repo.git.diff(cmd)
+    paths = diff.split("\n")
+    return paths

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -209,6 +209,12 @@ class ShowcaseText(BaseModel):
     text: str
 
 
+class DerivedFromProject(BaseModel):
+    project: str
+    git_repo_url: str
+    git_rev: str
+
+
 class ProjectInfo(BaseModel):
     """All of the project's information or metadata, written to the
     ``calkit.yaml`` file.
@@ -234,7 +240,7 @@ class ProjectInfo(BaseModel):
     description: str | None = None
     name: str | None = None
     git_repo_url: str | None = None
-    parent: str | None = None
+    derived_from: DerivedFromProject | None = None
     questions: list[str] = []
     datasets: list[Dataset] = []
     figures: list[Figure] = []

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -1,17 +1,95 @@
 # Version control
 
-Calkit is built upon
-[Git](https://git-scm.com) and
-[DVC](https://dvc.org) to enable keeping all project materials
-in version control.
-It provides a simplified interface to help reduce the number of
-decisions and steps necessary to interact with the repository and
-its remote storage.
-The lower-level tools `git` and `dvc` can be used if desired, however.
+Version control is one of the pillars of reproducibility.
+However, the current de facto version control system (VCS),
+[Git](https://git-scm.com),
+was designed primarily for complex software development projects,
+which provides lots of control and flexibility,
+but with a daunting learning curve.
+Since most of the value of version control for research projects comes from
+simply saving checkpoints of the project files so it's clear if they have
+changed, or so they can be reverted if something is broken,
+Calkit provides a simplified interface that focuses on just that.
+Additionally,
+since Git was not designed for large and/or binary files,
+Calkit uses [DVC](https://dvc.org) to version these file types.
+
+GitHub is currently the most popular location to back up
+Git repositories, or repos, in the cloud, but like Git,
+is primarily designed for software development.
+Similar to how Calkit is a layer on top of Git,
+The Calkit Cloud ([calkit.io](https://calkit.io))
+integrates with GitHub to provide a more purpose-built
+interface for research projects.
+It also serves as a default DVC remote,
+so users are not required to provision their own.
+
+Though Calkit adds a simplified interface on top of Git and DVC,
+the lower-level tools `git` and `dvc` can be used if desired, e.g.,
+for more complex operations.
+Thus, beginners can start with the Calkit interface and learn the
+lower-level tools along the way as needed.
+
+## Typical workflow
+
+In order to start working on a project,
+the project repository must exist on your local machine.
+This can be achieved either by creating a new repo or
+downloading, or "cloning," an existing one from the cloud.
+After a repo exists on your local machine,
+it is typical to repeat the cycle of
+committing new or changed files with a message describing them,
+and then pushing those commits to the cloud.
+This can be achieved with three workflow variants that provide increasing
+levels of automation alongside decreasing levels of control.
+
+```mermaid
+graph LR
+    init[calkit clone
+         or
+         calkit new project]
+    --> edit[create new
+             or edit files]
+    --> add[calkit add]
+    --> commit[calkit commit -m]
+    --> push[calkit push]
+    --> edit
+```
+
+The `add` step can be skipped for files that have been previously committed
+by adding the `-a` flag, i.e.,:
+
+```mermaid
+graph LR
+    init[calkit clone
+         or
+         calkit new project]
+    --> edit[create new
+             or edit files]
+    --> commit[calkit commit -a -m]
+    --> push[calkit push]
+    --> edit
+```
+
+The `add`, `commit`, and `push` steps can be combined into one with
+`calkit save`:
+
+```mermaid
+graph LR
+    init[calkit clone
+         or
+         calkit new project]
+    --> edit[create new
+             or edit files]
+    --> save[calkit save -a -m]
+    --> edit
+```
 
 ## Commands
 
-### `clone`
+### `calkit new project`
+
+### `calkit clone`
 
 `calkit clone` will download and create a local copy of the project,
 setup the default Calkit DVC remote and pull any files versioned with DVC.
@@ -21,7 +99,7 @@ The multi-step equivalent would be:
 - `calkit config remote`
 - `dvc pull`
 
-### `add`
+### `calkit add`
 
 `calkit add` will add a file to the repo staging area.
 Calkit will determine based on its type and size if it should be tracked
@@ -34,6 +112,10 @@ Options:
   and use the provided message.
 - `--push`: Push to the Git or DVC remote after committing.
 
-### `save`
+### `calkit save`
 
 `calkit save` will create a commit and push to the remotes in one step.
+It will automatically any ignore any files it deems to be inappropriate to
+save in version control.
+This provides the most automated and hands of experience
+but gives the least control.

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -4,9 +4,11 @@ Version control is one of the pillars of reproducibility.
 However, the current de facto version control system (VCS),
 [Git](https://git-scm.com),
 was designed primarily for complex software development projects,
-which provides lots of control and flexibility,
+and thus provides lots of control and flexibility,
 but with a daunting learning curve.
-Since most of the value of version control for research projects comes from
+
+Since most of the value of using version control for research
+projects comes from
 simply saving checkpoints of the project files so it's clear if they have
 changed, or so they can be reverted if something is broken,
 Calkit provides a simplified interface that focuses on just that.
@@ -14,12 +16,12 @@ Additionally,
 since Git was not designed for large and/or binary files,
 Calkit uses [DVC](https://dvc.org) to version these file types.
 
-GitHub is currently the most popular location to back up
+[GitHub](https://github.com) is currently the most popular location to back up
 Git repositories, or repos, in the cloud, but like Git,
 is primarily designed for software development.
 Similar to how Calkit is a layer on top of Git,
 The Calkit Cloud ([calkit.io](https://calkit.io))
-integrates with GitHub to provide a more purpose-built
+integrates with GitHub to add a more purpose-built
 interface for research projects.
 It also serves as a default DVC remote,
 so users are not required to provision their own.
@@ -27,8 +29,6 @@ so users are not required to provision their own.
 Though Calkit adds a simplified interface on top of Git and DVC,
 the lower-level tools `git` and `dvc` can be used if desired, e.g.,
 for more complex operations.
-Thus, beginners can start with the Calkit interface and learn the
-lower-level tools along the way as needed.
 
 ## Typical workflow
 
@@ -40,56 +40,79 @@ After a repo exists on your local machine,
 it is typical to repeat the cycle of
 committing new or changed files with a message describing them,
 and then pushing those commits to the cloud.
-This can be achieved with three workflow variants that provide increasing
-levels of automation alongside decreasing levels of control.
+This can be achieved with three workflow variants that trade off
+automation for control.
+
+The simplest and most hands-off uses `calkit save`,
+which will automatically make decisions about which files belong in Git
+which belong in DVC, which don't belong in either,
+commit them,
+and push them to the cloud all with a single command:
 
 ```mermaid
 graph LR
     init[calkit clone
          or
          calkit new project]
-    --> edit[create new
-             or edit files]
-    --> add[calkit add]
-    --> commit[calkit commit -m]
+    --> edit[create or
+             edit files]
+    --> save[calkit save -am
+             'Your message here']
+    --> edit
+```
+
+The `-a` flag indicates that we want to save all relevant files
+and the `-m` flag indicates that we are providing a message describing
+the changes.
+If omitted, Calkit will prompt the user for a message.
+
+If more control is desired,
+the `save` step can be broken down into `add`, `commit`
+and `push` steps.
+
+```mermaid
+graph LR
+    init[calkit clone
+         or
+         calkit new project]
+    --> edit[create or
+             edit files]
+    --> add["calkit add
+            {path1}
+            {path2}
+            ..."]
+    --> commit[calkit commit -m
+               'Your message here']
     --> push[calkit push]
     --> edit
 ```
 
 The `add` step can be skipped for files that have been previously committed
-by adding the `-a` flag, i.e.,:
+by adding the `-a` flag:
 
 ```mermaid
 graph LR
     init[calkit clone
          or
          calkit new project]
-    --> edit[create new
-             or edit files]
-    --> commit[calkit commit -a -m]
+    --> edit[create or
+             edit files]
+    --> commit[calkit commit -am
+               'Your message here']
     --> push[calkit push]
     --> edit
 ```
 
-The `add`, `commit`, and `push` steps can be combined into one with
-`calkit save`:
+If you have a collaborator working on the same project,
+any time they have pushed commits,
+you will need to pull
 
-```mermaid
-graph LR
-    init[calkit clone
-         or
-         calkit new project]
-    --> edit[create new
-             or edit files]
-    --> save[calkit save -a -m]
-    --> edit
-```
+## Command reference
 
-## Commands
+To view the help for any of these commands,
+execute `calkit {command} --help`.
 
-### `calkit new project`
-
-### `calkit clone`
+### `clone`
 
 `calkit clone` will download and create a local copy of the project,
 setup the default Calkit DVC remote and pull any files versioned with DVC.
@@ -99,9 +122,46 @@ The multi-step equivalent would be:
 - `calkit config remote`
 - `dvc pull`
 
-### `calkit add`
+### `status`
 
-`calkit add` will add a file to the repo staging area.
+`calkit status` will show the combined status from both Git and DVC.
+For example:
+
+```
+$ calkit status
+--------------------------- Code (Git) ---------------------------
+On branch main
+nothing to commit, working tree clean
+
+--------------------------- Data (DVC) ---------------------------
+No changes.
+
+------------------------- Pipeline (DVC) -------------------------
+Data and pipelines are up to date.
+```
+
+### `save`
+
+`calkit save` will create a commit and push to the remotes in one step.
+It will automatically any ignore any files it deems to be inappropriate to
+save in version control.
+This provides the most automated and hands of experience
+but gives the least control.
+
+Options:
+
+- `[PATHS]...`: Specify a list of paths to save. Not required if `--all` is
+  specified.
+- `--all`, `-a`: Save all paths.
+- `--to`, `-t`: Manually specify `git` or `dvc` as the tracking mechanism.
+- `--message`, `-m`: Specify a commit message. If omitted, the user will be
+  prompted for one.
+- `--no-push`: Do not push after committing.
+
+### `add`
+
+`calkit add` will add a file to the repo "staging area,"
+which sets it up to be committed.
 Calkit will determine based on its type and size if it should be tracked
 with Git or DVC and act accordingly.
 
@@ -111,11 +171,3 @@ Options:
 - `--commit-message`, `-m`: Create a commit after adding
   and use the provided message.
 - `--push`: Push to the Git or DVC remote after committing.
-
-### `calkit save`
-
-`calkit save` will create a commit and push to the remotes in one step.
-It will automatically any ignore any files it deems to be inappropriate to
-save in version control.
-This provides the most automated and hands of experience
-but gives the least control.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -69,7 +69,16 @@ markdown_extensions:
       pygments_lang_class: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      # Make exceptions to highlighting of code:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:mermaid2.fence_mermaid_custom
+plugins:
+  - search
+  - mermaid2
+
 extra:
   analytics:
     provider: google

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dev = [
 docs = [
   "mkdocs",
   "mkdocs-material",
+  "mkdocs-mermaid2-plugin"
 ]
 
 [project.urls]


### PR DESCRIPTION
- [x] Enable adding folders with `calkit add`
- [ ] Enable adding `"."` with `calkit add`
- [x] `calkit add` detects if a path is already tracked by DVC and adds it there if so
- [x] Add `upgrade` command for Calkit to upgrade itself (resolves #197)
- [x] Add `calkit init` command to initialize a project, similar to `calkit new project`.
- [x] Prompt for missing message in `calkit save` and `calkit commit`.