### PR TITLE
Add remote SSH environment support

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.16.3"
+__version__ = "0.17.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import glob
 import os
 import platform as _platform
 import subprocess
@@ -869,12 +870,19 @@ def run_in_env(
         # Now send any necessary files
         if send_paths:
             typer.echo("Sending to remote directory")
-            subprocess.check_call(
-                ["scp"]
+            # Accept glob patterns
+            paths = []
+            for p in send_paths:
+                paths += glob.glob(p)
+            scp_cmd = (
+                ["scp", "-r"]
                 + key_cmd
-                + send_paths
+                + paths
                 + [f"{user}@{host}:{remote_wdir}/"]
             )
+            if verbose:
+                typer.echo(f"scp cmd: {scp_cmd}")
+            subprocess.check_call(scp_cmd)
         # Now run the command
         # TODO: Use some sort of non-blocking job so we can disconnect and
         # resume

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -843,9 +843,6 @@ def run_in_env(
         except subprocess.CalledProcessError:
             raise_error(f"Failed to run in {kind}")
     elif env["kind"] == "ssh":
-        # Check if there's already a job running in this environment and don't
-        # start a new one if so
-        # TODO
         try:
             host = os.path.expandvars(env["host"])
             user = os.path.expandvars(env["user"])
@@ -905,8 +902,6 @@ def run_in_env(
                     typer.echo(f"scp cmd: {scp_cmd}")
                 subprocess.check_call(scp_cmd)
             # Now run the command
-            # TODO: Use some sort of non-blocking job so we can disconnect and
-            # resume
             typer.echo(f"Running remote command: {remote_shell_cmd}")
             if verbose:
                 typer.echo(f"Full command: {remote_cmd}")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -918,6 +918,15 @@ def run_in_env(
                 .strip()
             )
             typer.echo(f"Running with remote PID: {remote_pid}")
+            # Save PID to jobs database so we can resume waiting
+            typer.echo("Updating jobs database")
+            os.makedirs(".calkit", exist_ok=True)
+            job["remote_pid"] = remote_pid
+            job["submitted"] = time.time()
+            job["finished"] = None
+            jobs[job_key] = job
+            with open(jobs_fpath, "w") as f:
+                calkit.ryaml.dump(jobs, f)
         # Now wait for the job to complete
         typer.echo(f"Waiting for remote PID {remote_pid} to finish")
         ps_cmd = ["ssh"] + key_cmd + [f"{user}@{host}", "ps", "-p", remote_pid]
@@ -945,7 +954,7 @@ def run_in_env(
         typer.echo("Updating jobs database")
         os.makedirs(".calkit", exist_ok=True)
         job["remote_pid"] = None
-        job["last_finished"] = time.time()
+        job["finished"] = time.time()
         jobs[job_key] = job
         with open(jobs_fpath, "w") as f:
             calkit.ryaml.dump(jobs, f)

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -860,36 +860,76 @@ def run_in_env(
         if key is not None:
             key = os.path.expanduser(os.path.expandvars(key))
         remote_shell_cmd = _to_shell_cmd(cmd)
-        remote_cmd = f"cd '{remote_wdir}' && {remote_shell_cmd}"
+        # Run with nohup so we can disconnect
+        # TODO: Should we collect output instead of send to /dev/null?
+        remote_cmd = (
+            f"cd '{remote_wdir}' ; nohup {remote_shell_cmd} "
+            "> /dev/null 2>&1 & echo $! "
+        )
         key_cmd = ["-i", key] if key is not None else []
-        # First make sure the remote working dir exists
-        typer.echo("Ensuring remote working directory exists")
-        subprocess.check_call(
-            ["ssh"] + key_cmd + [f"{user}@{host}", f"mkdir -p {remote_wdir}"]
-        )
-        # Now send any necessary files
-        if send_paths:
-            typer.echo("Sending to remote directory")
-            # Accept glob patterns
-            paths = []
-            for p in send_paths:
-                paths += glob.glob(p)
-            scp_cmd = (
-                ["scp", "-r"]
+        # Check to see if we've already submitted a job with this command
+        jobs_fpath = ".calkit/jobs.yaml"
+        job_key = f"{env_name}::{remote_shell_cmd}"
+        remote_pid = None
+        if os.path.isfile(jobs_fpath):
+            with open(jobs_fpath) as f:
+                jobs = calkit.ryaml.load(f)
+            if jobs is None:
+                jobs = {}
+        else:
+            jobs = {}
+        job = jobs.get(job_key, {})
+        remote_pid = job.get("remote_pid")
+        if remote_pid is None:
+            # First make sure the remote working dir exists
+            typer.echo("Ensuring remote working directory exists")
+            subprocess.check_call(
+                ["ssh"]
                 + key_cmd
-                + paths
-                + [f"{user}@{host}:{remote_wdir}/"]
+                + [f"{user}@{host}", f"mkdir -p {remote_wdir}"]
             )
+            # Now send any necessary files
+            if send_paths:
+                typer.echo("Sending to remote directory")
+                # Accept glob patterns
+                paths = []
+                for p in send_paths:
+                    paths += glob.glob(p)
+                scp_cmd = (
+                    ["scp", "-r"]
+                    + key_cmd
+                    + paths
+                    + [f"{user}@{host}:{remote_wdir}/"]
+                )
+                if verbose:
+                    typer.echo(f"scp cmd: {scp_cmd}")
+                subprocess.check_call(scp_cmd)
+            # Now run the command
+            # TODO: Use some sort of non-blocking job so we can disconnect and
+            # resume
+            typer.echo(f"Running remote command: {remote_shell_cmd}")
             if verbose:
-                typer.echo(f"scp cmd: {scp_cmd}")
-            subprocess.check_call(scp_cmd)
-        # Now run the command
-        # TODO: Use some sort of non-blocking job so we can disconnect and
-        # resume
-        typer.echo(f"Running remote command: {remote_cmd}")
-        subprocess.check_call(
-            ["ssh"] + key_cmd + [f"{user}@{host}", remote_cmd]
-        )
+                typer.echo(f"Full command: {remote_cmd}")
+            remote_pid = (
+                subprocess.check_output(
+                    ["ssh"] + key_cmd + [f"{user}@{host}", remote_cmd]
+                )
+                .decode()
+                .strip()
+            )
+            typer.echo(f"Running with remote PID: {remote_pid}")
+        # Now wait for the job to complete
+        typer.echo(f"Waiting for remote PID {remote_pid} to finish")
+        ps_cmd = ["ssh"] + key_cmd + [f"{user}@{host}", "ps", "-p", remote_pid]
+        finished = False
+        while not finished:
+            try:
+                subprocess.check_output(ps_cmd)
+                finished = False
+                time.sleep(2)
+            except subprocess.CalledProcessError:
+                finished = True
+                typer.echo("Remote process finished")
         # Now sync the files back
         # TODO: Figure out how to do this in one command
         # Getting the syntax right is troublesome since it appears to work
@@ -901,6 +941,14 @@ def run_in_env(
                 src = f"{user}@{host}:{src_path}"
                 scp_cmd = ["scp", "-r"] + key_cmd + [src, "."]
                 subprocess.check_call(scp_cmd)
+        # Now delete the remote PID from the jobs file
+        typer.echo("Updating jobs database")
+        os.makedirs(".calkit", exist_ok=True)
+        job["remote_pid"] = None
+        job["last_finished"] = time.time()
+        jobs[job_key] = job
+        with open(jobs_fpath, "w") as f:
+            calkit.ryaml.dump(jobs, f)
     else:
         raise_error("Environment kind not supported")
 

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -1155,9 +1155,17 @@ def set_env_var(
 @app.command(name="upgrade")
 def upgrade():
     """Upgrade Calkit."""
-    # See if uv is installed first
-    if calkit.check_dep_exists("uv"):
-        cmd = ["uv", "pip", "install", "--system"]
+    if calkit.check_dep_exists("pipx"):
+        cmd = ["pipx", "upgrade", "calkit-python"]
+    elif calkit.check_dep_exists("uv"):
+        cmd = [
+            "uv",
+            "pip",
+            "install",
+            "--system",
+            "--upgrade",
+            "calkit-python",
+        ]
     else:
-        cmd = ["pip", "install"]
-    subprocess.run(cmd + ["--upgrade", "calkit-python"])
+        cmd = ["pip", "install", "--upgrade", "calkit-python"]
+    subprocess.run(cmd)

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -109,6 +109,16 @@ class REnvironment(Environment):
     prefix: str
 
 
+class SSHEnvironment(BaseModel):
+    kind: Literal["ssh"]
+    host: str
+    user: str
+    wdir: str
+    key: str | None = None
+    send_paths: list[str] = ["./*"]
+    get_paths: list[str] = ["*"]
+
+
 class Software(BaseModel):
     title: str
     path: str
@@ -248,7 +258,11 @@ class ProjectInfo(BaseModel):
     references: list[ReferenceCollection] = []
     environments: dict[
         str,
-        Environment | DockerEnvironment | VenvEnvironment | UvVenvEnvironment,
+        Environment
+        | DockerEnvironment
+        | VenvEnvironment
+        | UvVenvEnvironment
+        | SSHEnvironment,
     ] = {}
     software: list[Software] = []
     notebooks: list[Notebook] = []

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -293,6 +293,12 @@ and which we want to copy back after they finish.
 Wildcards in paths are supported, so the entire directory could be copied
 if desired by specifying `*`.
 
+To register an SSH key with the host, use `ssh-copy-id`. For example:
+
+```sh
+ssh-copy-id -i ~/.ssh/id_ed25519 my-user-name@10.225.22.25
+```
+
 To execute a command in this environment, we can add a stage like this
 to our DVC pipeline in `dvc.yaml`:
 

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -23,6 +23,7 @@ Calkit supports defining and running code in these environment types:
 - [`uv`](https://docs.astral.sh/uv/) (both `venv` and project-based)
 - [Pixi](https://github.com/prefix-dev/pixi)
 - [`renv`](https://rstudio.github.io/renv/index.html)
+- `ssh`
 
 Environment definitions live in the project's `calkit.yaml` file
 in the `environments` section.
@@ -253,3 +254,54 @@ and an updated `environment-lock.yml` file will be created.
 Again this highlights Calkit's declarative design philosophy.
 Declare the environment and what command should be executed inside,
 and Calkit will handle the rest.
+
+### SSH
+
+It's possible to define a remote environment that uses `ssh` to connect
+and run commands,
+and `scp` to copy files back and forth.
+This could be useful, e.g.,
+for running one or more pipeline stages on a high performance computing (HPC)
+cluster,
+or simply offloading some work to a virtual machine in the cloud
+with specialized hardware like a more powerful GPU.
+
+It is assumed that dependencies on the remote machine are managed separately.
+
+An SSH environment defined in `calkit.yaml` looks like:
+
+```yaml
+environments:
+  cluster:
+    kind: ssh
+    host: "10.225.22.25"
+    user: my-user-name
+    wdir: /home/my-user-name/calkit/example-ssh
+    key: ~/.ssh/id_ed25519
+    send_paths:
+      - script.sh
+    get_paths:
+      - results
+```
+
+In the example above, we define an environment called `cluster`,
+where we specify the host IP address, our username on that machine,
+the working directory, the path to an SSH key on our local machine
+(so we can connect without a password),
+which paths we want to send before executing commands,
+and which we want to copy back after they finish.
+Wildcards in paths are supported, so the entire directory could be copied
+if desired by specifying `*`.
+
+To execute a command in this environment, we can add a stage like this
+to our DVC pipeline in `dvc.yaml`:
+
+```yaml
+stages:
+  run-simulation:
+    cmd: calkit xenv -n cluster bash script.sh
+    deps:
+      - script.sh
+    outs:
+      - results
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,3 +64,13 @@ Features:
 - A LaTeX document built with a Docker container
 - A direct numerical simulation dataset for validation imported from a
   different project, derived from the Johns Hopkins Turbulence Database
+
+## SSH
+
+[Project page](https://calkit.io/calkit/example-ssh) |
+[GitHub repo](https://github.com/calkit/example-ssh)
+
+Features:
+
+- An SSH environment for running a remote command over SSH and copying back
+  results to the local machine

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -52,6 +52,7 @@ Features:
 - Environmental variable dependencies
 - A pipeline designed to be run periodically to accumulate new data
 - A project showcase with interactive Plotly figures
+- A uv project-based environment and dedicated Python package
 
 ## OpenFOAM RANS boundary later validation
 


### PR DESCRIPTION
## TODO

- [x] Allow jobs to continue running even if disconnected, where if we run the same command again, we ensure the previous has exited on the remote machine before copying back any files.
- [ ] Add unit test for this? We could just SSH to localhost.
- [ ] Fails on Windows because Git checks out files with Windows line endings, which get sent to the host as-is.
- [x] Docs for environments and examples page
- [ ] Ability to simply get a shell in that environment -- perhaps `calkit shell` would be better for that
- [ ] Default copy to and back? Also allow setting that in the command?

Resolves #14 

Example project: https://github.com/calkit/example-ssh