### PR TITLE
Allow using `.` in `calkit add`

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.0"
+__version__ = "0.17.1"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -212,7 +212,17 @@ def add(
     try:
         repo = git.Repo()
     except InvalidGitRepositoryError:
-        raise_error("Not currently in a Git repo; run `calkit init` first")
+        # Prompt user if they want to run git init here
+        warn("Current directory is not a Git repo")
+        auto_init = typer.confirm(
+            "Do you want to initialize the current directory with Git?",
+            default=False,
+        )
+        if auto_init:
+            subprocess.check_call(["git", "init"])
+        else:
+            raise_error("Not currently in a Git repo; run `calkit init` first")
+        repo = git.Repo()
     try:
         dvc_repo = dvc.repo.Repo()
     except NotDvcRepoError:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -409,40 +409,7 @@ def save(
     if paths is not None:
         add(paths, to=to)
     elif save_all:
-        # First check to see if we should commit anything to DVC
-        dvc_repo = dvc.repo.Repo()
-        dvc_status = dvc_repo.data_status()
-        for dvc_uncommitted in dvc_status["uncommitted"].get("modified", []):
-            typer.echo(f"Adding {dvc_uncommitted} to DVC")
-            dvc_repo.commit(dvc_uncommitted, force=True)
-        repo = git.Repo()
-        untracked_git_files = repo.untracked_files
-        for untracked_file in untracked_git_files:
-            if (
-                any(
-                    [
-                        untracked_file.endswith(suffix)
-                        for suffix in AUTO_IGNORE_SUFFIXES
-                    ]
-                )
-                or any(
-                    [
-                        untracked_file.startswith(prefix)
-                        for prefix in AUTO_IGNORE_PREFIXES
-                    ]
-                )
-                or untracked_file in AUTO_IGNORE_PATHS
-            ):
-                typer.echo(f"Automatically ignoring {untracked_file}")
-                with open(".gitignore", "a") as f:
-                    f.write("\n" + untracked_file + "\n")
-        # TODO: Figure out if we should group large folders for dvc
-        # Now add untracked files automatically
-        for untracked_file in repo.untracked_files:
-            add(paths=[untracked_file])
-        # Now add changed files
-        for changed_file in [d.a_path for d in repo.index.diff(None)]:
-            repo.git.add(changed_file)
+        add(paths=["."])
     if message is None:
         typer.echo("No message provided; entering interactive mode")
         typer.echo("Creating a commit including the following paths:")

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -274,6 +274,5 @@ def test_add(tmp_dir):
     subprocess.check_call(["calkit", "add", "data"])
     assert "data.dvc" in calkit.git.get_staged_files()
     assert "data" in calkit.dvc.list_paths()
-    # Check that we can't run `calkit add .`
-    with pytest.raises(subprocess.CalledProcessError):
-        subprocess.check_call(["calkit", "add", "."])
+    # Check that we can run `calkit add .`
+    subprocess.check_call(["calkit", "add", "."])


### PR DESCRIPTION
We also prompt the user to create a Git repo if one does not exist.