### PR TITLE
Make calkit config remote commit changes by default

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.4"
+__version__ = "0.17.5"
 
 from .core import *
 from . import git


### PR DESCRIPTION
If we don't do this, DVC will complain if we try to push, since it needs to read a committed config file.