### PR TITLE
Add datasets docs and more Git helper functionality

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.5"
+__version__ = "0.17.6"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -155,6 +155,27 @@ def clone(
     """Clone a Git repo and by default configure and pull from the DVC
     remote.
     """
+    # If the URL looks like just a project owner and name, fetch its repo URL
+    # first
+    if not url.startswith("https://") and not url.startswith("git@"):
+        url_split = url.split("/")
+        if len(url_split) != 2:
+            raise_error(
+                "Calkit projects must be specified like "
+                "{owner_name}/{project_name}"
+            )
+        owner_name, project_name = url_split
+        typer.echo("Fetching Git repo URL from the Calkit Cloud")
+        try:
+            project = calkit.cloud.get(
+                f"/projects/{owner_name}/{project_name}"
+            )
+        except Exception as e:
+            raise_error(f"Failed to fetch project information: {e}")
+        url = project["git_repo_url"]
+        # TODO: Figure out if we should clone with SSH
+        if not url.endswith(".git"):
+            url += ".git"
     # Git clone
     cmd = ["git", "clone", url]
     if recursive:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -498,6 +498,33 @@ def push(
         raise_error("DVC push failed")
 
 
+@app.command(name="ignore")
+def ignore(
+    path: Annotated[str, typer.Argument(help="Path to ignore.")],
+    no_commit: Annotated[
+        bool,
+        typer.Option(
+            "--no-commit", help="Do not commit changes to .gitignore."
+        ),
+    ] = False,
+):
+    """Ignore a file, i.e., keep it out of version control."""
+    repo = git.Repo()
+    if repo.ignored(path):
+        typer.echo(f"{path} is already ignored")
+        exit(0)
+    typer.echo(f"Adding '{path}' to .gitignore")
+    txt = "\n" + path + "\n"
+    with open(".gitignore", "a") as f:
+        f.write(txt)
+    if not no_commit:
+        repo = git.Repo()
+        repo.git.reset()
+        repo.git.add(".gitignore")
+        if calkit.git.get_staged_files():
+            repo.git.commit(["-m", f"Ignore {path}"])
+
+
 @app.command(name="local-server")
 def run_local_server():
     """Run the local server to interact over HTTP."""

--- a/docs/calkit-yaml.md
+++ b/docs/calkit-yaml.md
@@ -7,7 +7,7 @@ for the project's important metadata, which includes its:
   (applications, libraries, environmental variables)
 - Questions the project seeks to answer
 - Environments
-- Datasets
+- [Datasets](datasets.md)
 - Figures
 - Publications (journal articles, conference papers, presentations, posters)
 - [Procedures](tutorials/procedures.md)

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -1,0 +1,31 @@
+# Datasets
+
+If your research project produces a dataset,
+you can indicate it as such to make it easy for others to reuse in their
+own project.
+These are listed in the `datasets` section of the project's `calkit.yaml`.
+
+A dataset is identified by its path in the project repo,
+and this path can be a folder.
+For example:
+
+```yaml
+# In calkit.yaml
+datasets:
+  - path: data/raw-data.csv
+    title: Raw data
+    description: This is the raw data.
+```
+
+## Importing or reusing a dataset from another project
+
+A dataset can be imported with the CLI like:
+
+```sh
+calkit import dataset {owner_name}/{project_name}/{path} {local_path}
+```
+
+If this dataset is tracked with DVC,
+a new DVC remote will be created to pull it into your project.
+For datasets in the Calkit Cloud,
+this means the data will not be duplicated there.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -3,7 +3,7 @@
 If your research project produces a dataset,
 you can indicate it as such to make it easy for others to reuse in their
 own project.
-These are listed in the `datasets` section of the project's `calkit.yaml`.
+These are listed in the `datasets` section of the project's `calkit.yaml` file.
 
 A dataset is identified by its path in the project repo,
 and this path can be a folder.

--- a/docs/version-control.md
+++ b/docs/version-control.md
@@ -122,6 +122,13 @@ The multi-step equivalent would be:
 - `calkit config remote`
 - `dvc pull`
 
+If the project is hosted on the Calkit Cloud, it can be referenced by
+name rather than Git repo URL. For example:
+
+```sh
+calkit clone petebachant/strava-analysis
+```
+
 ### `status`
 
 `calkit status` will show the combined status from both Git and DVC.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - pipeline/index.md
       - pipeline/manual-steps.md
   - The calkit.yaml file: calkit-yaml.md
+  - Datasets: datasets.md
   - Environments: environments.md
   - References: references.md
   - Calculations: calculations.md


### PR DESCRIPTION
- `calkit clone` can now reference a project owner/name instead of a full URL
- `calkit ignore` will add a file to `.gitignore` if necessary

Towards #156 