### PR TITLE
Add project status log

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.17.6"
+__version__ = "0.18.0"
 
 from .core import *
 from . import git

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -70,7 +70,7 @@ def setup_remote(
     if not no_commit:
         repo = git.Repo()
         repo.git.add(".dvc/config")
-        if calkit.git.get_staged_files():
+        if ".dvc/config" in calkit.git.get_staged_files():
             typer.echo("Committing changes to DVC config")
             repo.git.commit([".dvc/config", "-m", "Set DVC remote"])
 

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -65,13 +65,14 @@ def setup_remote(
         raise_error("DVC remote config failed; have you run `dvc init`?")
     except InvalidGitRepositoryError:
         raise_error("Current directory is not a Git repository")
+    except ValueError as e:
+        raise_error(e)
     if not no_commit:
         repo = git.Repo()
-        repo.git.reset()
         repo.git.add(".dvc/config")
         if calkit.git.get_staged_files():
             typer.echo("Committing changes to DVC config")
-            repo.git.commit(["-m", "Set DVC remote"])
+            repo.git.commit([".dvc/config", "-m", "Set DVC remote"])
 
 
 @config_app.command(name="setup-remote-auth", help="Alias for 'remote-auth'.")

--- a/calkit/cli/core.py
+++ b/calkit/cli/core.py
@@ -11,7 +11,10 @@ def print_sep(name: str):
     txt_width = len(name) + 2
     buffer_width = (width - txt_width) // 2
     buffer = "-" * buffer_width
-    typer.echo(f"{buffer} {name} {buffer}")
+    line = f"{buffer} {name} {buffer}"
+    if len(line) == (width - 1):
+        line += "-"
+    typer.echo(line)
 
 
 def run_cmd(cmd: list[str]):

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -210,7 +210,7 @@ def get_status():
     """Get a unified Git and DVC status."""
     print_sep("Project")
     # Print latest status
-    status = calkit.get_current_project_status()
+    status = calkit.get_latest_project_status()
     if status is not None:
         ts = status.timestamp.strftime("%Y-%m-%d %H:%M:%S")
         colors = {

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -9,7 +9,6 @@ import platform as _platform
 import subprocess
 import sys
 import time
-from datetime import datetime
 
 import dotenv
 import dvc.repo
@@ -211,20 +210,15 @@ def get_status():
     """Get a unified Git and DVC status."""
     print_sep("Project")
     # Print latest status
-    fpath = os.path.join(".calkit", "status.csv")
-    if os.path.isfile(fpath):
-        with open(fpath) as f:
-            reader = csv.reader(f)
-            last_line = list(reader)[-1]
-        ts, status, _ = last_line
-        ts = datetime.fromisoformat(ts)
-        ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+    status = calkit.get_current_project_status()
+    if status is not None:
+        ts = status.timestamp.strftime("%Y-%m-%d %H:%M:%S")
         colors = {
             "in-progress": "blue",
             "on-hold": "yellow",
             "completed": "green",
         }
-        status_txt = typer.style(status, fg=colors.get(status))
+        status_txt = typer.style(status.status, fg=colors.get(status.status))
         typer.echo(f"Current status: {status_txt} (updated {ts} UTC)")
     else:
         typer.echo(

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -9,6 +9,7 @@ import platform as _platform
 import subprocess
 import sys
 import time
+from datetime import datetime
 
 import dotenv
 import dvc.repo
@@ -208,6 +209,28 @@ def clone(
 @app.command(name="status")
 def get_status():
     """Get a unified Git and DVC status."""
+    print_sep("Project")
+    # Print latest status
+    fpath = os.path.join(".calkit", "status.csv")
+    if os.path.isfile(fpath):
+        with open(fpath) as f:
+            reader = csv.reader(f)
+            last_line = list(reader)[-1]
+        ts, status, _ = last_line
+        ts = datetime.fromisoformat(ts)
+        ts = ts.strftime("%Y-%m-%d %H:%M:%S")
+        colors = {
+            "in-progress": "blue",
+            "on-hold": "yellow",
+            "completed": "green",
+        }
+        status_txt = typer.style(status, fg=colors.get(status))
+        typer.echo(f"Current status: {status_txt} (updated {ts} UTC)")
+    else:
+        typer.echo(
+            'Project status not set. Use "calkit new status" to update.'
+        )
+    typer.echo()
     print_sep("Code (Git)")
     run_cmd(["git", "status"])
     typer.echo()

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import csv
 import glob
 import json
 import logging
@@ -10,6 +11,8 @@ import os
 import pickle
 import re
 import subprocess
+
+from calkit.models import ProjectStatus
 
 import requests
 
@@ -385,3 +388,16 @@ def get_size(path: str):
 def to_kebab_case(str) -> str:
     """Convert a string to kebab-case."""
     return re.sub(r"[-_,\.\ ]", "-", str.lower())
+
+
+def get_current_project_status(wdir: str = None) -> ProjectStatus | None:
+    fpath = os.path.join(".calkit", "status.csv")
+    if wdir is not None:
+        fpath = os.path.join(wdir, fpath)
+    if os.path.isfile(fpath):
+        with open(fpath) as f:
+            reader = csv.reader(f)
+            last_line = list(reader)[-1]
+        ts, status, message = last_line
+        ts = datetime.fromisoformat(ts)
+        return ProjectStatus(timestamp=ts, status=status, message=message)

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -390,7 +390,7 @@ def to_kebab_case(str) -> str:
     return re.sub(r"[-_,\.\ ]", "-", str.lower())
 
 
-def get_current_project_status(wdir: str = None) -> ProjectStatus | None:
+def get_latest_project_status(wdir: str = None) -> ProjectStatus | None:
     fpath = os.path.join(".calkit", "status.csv")
     if wdir is not None:
         fpath = os.path.join(wdir, fpath)

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -390,14 +390,30 @@ def to_kebab_case(str) -> str:
     return re.sub(r"[-_,\.\ ]", "-", str.lower())
 
 
-def get_latest_project_status(wdir: str = None) -> ProjectStatus | None:
+def get_project_status_history(
+    wdir: str = None, as_pydantic=True
+) -> list[ProjectStatus] | list[dict]:
+    statuses = []
     fpath = os.path.join(".calkit", "status.csv")
     if wdir is not None:
         fpath = os.path.join(wdir, fpath)
     if os.path.isfile(fpath):
         with open(fpath) as f:
             reader = csv.reader(f)
-            last_line = list(reader)[-1]
-        ts, status, message = last_line
-        ts = datetime.fromisoformat(ts)
-        return ProjectStatus(timestamp=ts, status=status, message=message)
+            next(reader, None)  # Skip header row
+            for line in reader:
+                ts, status, message = line
+                ts = datetime.fromisoformat(ts)
+                obj = ProjectStatus(
+                    timestamp=ts, status=status, message=message
+                )
+                if not as_pydantic:
+                    obj = obj.model_dump()
+                statuses.append(obj)
+    return statuses
+
+
+def get_latest_project_status(wdir: str = None) -> ProjectStatus | None:
+    statuses = get_project_status_history(wdir=wdir)
+    if statuses:
+        return statuses[-1]

--- a/calkit/dvc.py
+++ b/calkit/dvc.py
@@ -31,9 +31,12 @@ def configure_remote(wdir: str = None):
         # Try to fetch Git repo URL from Calkit cloud
         try:
             project = calkit.cloud.get(f"/projects/{project_name}")
+            url = project["git_repo_url"]
         except Exception as e:
             raise ValueError(f"Could not fetch project info: {e}")
-        repo.git.remote(["add", "origin", project["git_repo_url"]])
+        if not url.endswith(".git"):
+            url += ".git"
+        repo.git.remote(["add", "origin", url])
     base_url = calkit.cloud.get_base_url()
     remote_url = f"{base_url}/projects/{project_name}/dvc"
     subprocess.check_call(

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -12,9 +12,13 @@ def detect_project_name(path: str = None) -> str:
     ck_info = calkit.load_calkit_info(wdir=path)
     name = ck_info.get("name")
     owner = ck_info.get("owner")
-    url = git.Repo(path=path).remote().url
-    from_url = url.split("github.com")[-1][1:].removesuffix(".git")
-    owner_name, project_name = from_url.split("/")
+    if name is None or owner is None:
+        try:
+            url = git.Repo(path=path).remote().url
+        except ValueError:
+            raise ValueError("No Git remote set with name 'origin'")
+        from_url = url.split("github.com")[-1][1:].removesuffix(".git")
+        owner_name, project_name = from_url.split("/")
     if name is None:
         name = project_name
     if owner is None:

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Literal
 
 from pydantic import BaseModel
@@ -223,6 +223,12 @@ class DerivedFromProject(BaseModel):
     project: str
     git_repo_url: str
     git_rev: str
+
+
+class ProjectStatus(BaseModel):
+    timestamp: datetime
+    status: Literal["in-progress", "on-hold", "completed"]
+    message: str | None = None
 
 
 class ProjectInfo(BaseModel):

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -303,14 +303,14 @@ def test_status(tmp_dir):
     subprocess.check_call(["calkit", "init"])
     subprocess.check_call(["calkit", "new", "status", "in-progress"])
     subprocess.check_call(["calkit", "status"])
-    status = calkit.get_current_project_status()
+    status = calkit.get_latest_project_status()
     assert status.status == "in-progress"
     assert not status.message
     subprocess.check_call(
         ["calkit", "new", "status", "completed", "-m", "We're done."]
     )
     subprocess.check_call(["calkit", "status"])
-    status = calkit.get_current_project_status()
+    status = calkit.get_latest_project_status()
     assert status.status == "completed"
     assert status.message == "We're done."
     with pytest.raises(subprocess.CalledProcessError):

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -296,3 +296,22 @@ def test_add(tmp_dir):
         f.write(os.urandom(2_000_000))
     subprocess.check_call(["calkit", "add", "data2", "-M"])
     assert repo.head.commit.message.strip() == "Add data2"
+
+
+def test_status(tmp_dir):
+    subprocess.check_call(["calkit", "status"])
+    subprocess.check_call(["calkit", "init"])
+    subprocess.check_call(["calkit", "new", "status", "in-progress"])
+    subprocess.check_call(["calkit", "status"])
+    status = calkit.get_current_project_status()
+    assert status.status == "in-progress"
+    assert not status.message
+    subprocess.check_call(
+        ["calkit", "new", "status", "completed", "-m", "We're done."]
+    )
+    subprocess.check_call(["calkit", "status"])
+    status = calkit.get_current_project_status()
+    assert status.status == "completed"
+    assert status.message == "We're done."
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(["calkit", "new", "status", "very-cool"])

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -313,5 +313,8 @@ def test_status(tmp_dir):
     status = calkit.get_latest_project_status()
     assert status.status == "completed"
     assert status.message == "We're done."
+    history = calkit.get_project_status_history()
+    assert history[-1] == status
+    calkit.get_project_status_history(as_pydantic=False)
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call(["calkit", "new", "status", "very-cool"])


### PR DESCRIPTION
Related to https://github.com/calkit/calkit-cloud/issues/110

We can store project status completely locally in the repo and GET/POST via API.

## TODO

- [ ] Is CSV the right format, i.e., should we consider YAML? -- CSV works nicely since `git blame` can operate on a single row and tell us when it was added and by whom