### PR TITLE
Make dataset importing more flexible

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 from .core import *
 from . import git

--- a/calkit/cli/import_.py
+++ b/calkit/cli/import_.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import base64
 import os
 import subprocess
 from typing import Annotated
 
 import git
+import requests
 import typer
+from tqdm import tqdm
 
 import calkit
 from calkit.cli import raise_error
@@ -30,6 +33,23 @@ def import_dataset(
         str,
         typer.Argument(help="Output path at which to save."),
     ] = None,
+    filter_paths: Annotated[
+        list[str],
+        typer.Option(
+            "--filter-paths",
+            help="Filter paths in target dataset if it's a folder.",
+        ),
+    ] = None,
+    no_commit: Annotated[
+        bool,
+        typer.Option("--no-commit", help="Do not commit changes to repo."),
+    ] = False,
+    no_dvc_pull: Annotated[
+        bool,
+        typer.Option(
+            "--no-dvc-pull", help="Do not pull imported dataset with DVC."
+        ),
+    ] = False,
     overwrite: Annotated[
         bool,
         typer.Option(
@@ -49,58 +69,111 @@ def import_dataset(
     project_name = path_split[1]
     path = "/".join(path_split[2:])
     if dest_path is None:
-        dest_path = path
+        ds_dest_path = path
+    else:
+        ds_dest_path = dest_path
     ck_info = calkit.load_calkit_info()
     datasets = ck_info.get("datasets", [])
     ds_paths = [ds["path"] for ds in datasets]
-    if not overwrite and dest_path in ds_paths:
-        raise ValueError(
-            "A dataset already exists in this project at this path"
-        )
-    elif overwrite and dest_path in ds_paths:
-        datasets = [ds for ds in datasets if ds["path"] != dest_path]
+    if not overwrite and ds_dest_path in ds_paths:
+        raise_error("A dataset already exists in this project at this path")
+    elif overwrite and ds_dest_path in ds_paths:
+        datasets = [ds for ds in datasets if ds["path"] != ds_dest_path]
     repo = git.Repo()
-    # Obtain, save, and commit the .dvc file for the dataset
+    # Obtain, save, and commit the .dvc file for the dataset, or if this is
+    # kept in Git, just download the files and commit them here
     typer.echo("Fetching import info")
-    resp = calkit.cloud.get(
-        f"/projects/{owner_name}/{project_name}/datasets/{path}"
-    )
-    if "dvc_import" not in resp:
-        raise ValueError("This file is not available to import with DVC")
-    dvc_fpath = dest_path + ".dvc"
-    dvc_dir = os.path.dirname(dvc_fpath)
-    os.makedirs(dvc_dir, exist_ok=True)
-    # Update path in .dvc file if necessary
-    dvc_import = resp["dvc_import"]
-    dvc_import["outs"][0]["path"] = os.path.basename(dest_path)
-    typer.echo("Saving .dvc file")
-    with open(dvc_fpath, "w") as f:
-        calkit.ryaml.dump(dvc_import, f)
-    repo.git.add(dvc_fpath)
-    # Ensure we have a DVC remote corresponding to this project, and that we
-    # have a token set for that remote
-    typer.echo("Adding new DVC remote")
-    calkit.dvc.add_external_remote(
-        owner_name=owner_name, project_name=project_name
-    )
-    repo.git.add(".dvc/config")
-    # Add to .gitignore
-    typer.echo("Checking .gitignore")
-    if os.path.isfile(".gitignore"):
-        with open(".gitignore") as f:
-            gitignore = f.read()
+    params = None
+    if filter_paths is not None:
+        params = {"filter_paths": filter_paths}
+    try:
+        resp = calkit.cloud.get(
+            f"/projects/{owner_name}/{project_name}/datasets/{path}",
+            params=params,
+        )
+    except Exception as e:
+        raise_error(f"Failed to fetch dataset info from cloud: {e}")
+    dvc_import, git_import = resp["dvc_import"], resp["git_import"]
+    if dest_path is not None:
+        typer.echo(f"Importing to destination path: {dest_path}")
+    if dvc_import is not None:
+        if dest_path is not None and len(dvc_import["outs"]) > 1:
+            raise_error(
+                "Cannot specify destination path when importing multiple "
+                "DVC files"
+            )
+        # Import this data with DVC
+        dvc_fpath = ds_dest_path + ".dvc"
+        dvc_dir = os.path.dirname(dvc_fpath)
+        os.makedirs(dvc_dir, exist_ok=True)
+        # Update paths in .dvc file so they are relative to the DVC file
+        for n, out in enumerate(dvc_import["outs"]):
+            dvc_import["outs"][n]["path"] = os.path.relpath(
+                out["path"], dvc_dir
+            )
+        typer.echo("Saving .dvc file")
+        with open(dvc_fpath, "w") as f:
+            calkit.ryaml.dump(dvc_import, f)
+        repo.git.add(dvc_fpath)
+        # Ensure we have a DVC remote corresponding to this project, and that we
+        # have a token set for that remote
+        typer.echo("Adding new DVC remote")
+        calkit.dvc.add_external_remote(
+            owner_name=owner_name, project_name=project_name
+        )
+        repo.git.add(".dvc/config")
+        # Add to .gitignore
+        typer.echo("Checking .gitignore")
+        if os.path.isfile(".gitignore"):
+            with open(".gitignore") as f:
+                gitignore = f.read()
+        else:
+            gitignore = ""
+        if ds_dest_path not in gitignore.split("\n"):
+            typer.echo(f"Adding {ds_dest_path} to .gitignore")
+            gitignore = gitignore.rstrip() + "\n" + ds_dest_path + "\n"
+            with open(".gitignore", "w") as f:
+                f.write(gitignore)
+            repo.git.add(".gitignore")
+    elif git_import is not None:
+        typer.echo("Fetching files directly since they're kept in Git")
+        files = git_import["files"]
+        if dest_path is not None:
+            os.makedirs(dest_path, exist_ok=True)
+        for f in tqdm(files):
+            # Fetch content from API
+            resp_i = calkit.cloud.get(
+                f"/projects/{owner_name}/{project_name}/contents/{f}"
+            )
+            content = resp_i.get("content")
+            fname = os.path.basename(f)
+            dirname = os.path.dirname(f) if dest_path is None else dest_path
+            os.makedirs(dirname, exist_ok=True)
+            out_path = os.path.join(dirname, fname)
+            if content is not None:
+                # Decode base64 content and save locally
+                with open(out_path, "wb") as f:
+                    f.write(base64.b64decode(content))
+            else:
+                url = resp_i.get("url")
+                if url is None:
+                    raise_error(f"Could not fetch {f}")
+                # Download from URL
+                resp_dl = requests.get(url, stream=True)
+                try:
+                    resp_dl.raise_for_status()
+                except Exception as e:
+                    raise_error(f"Failed to download {f} from {url}: {e}")
+                with open(out_path, "wb") as f:
+                    for chunk in resp_dl.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            repo.git.add(out_path)
     else:
-        gitignore = ""
-    if dest_path not in gitignore.split("\n"):
-        typer.echo(f"Adding {dest_path} to .gitignore")
-        gitignore = gitignore.rstrip() + "\n" + dest_path + "\n"
-        with open(".gitignore", "w") as f:
-            f.write(gitignore)
-        repo.git.add(".gitignore")
+        raise_error("Could not fetch import info from Calkit Cloud")
     # Add to datasets in calkit.yaml
     typer.echo("Adding dataset to calkit.yaml")
     new_ds = calkit.models.ImportedDataset(
-        path=dest_path,
+        path=ds_dest_path,
         title=resp.get("title"),
         description=resp.get("description"),
         stage=None,
@@ -108,6 +181,7 @@ def import_dataset(
             project=f"{owner_name}/{project_name}",
             path=path,
             git_rev=None,  # TODO?
+            filter_paths=filter_paths,
         ),
     )
     datasets.append(new_ds.model_dump())
@@ -115,12 +189,14 @@ def import_dataset(
     with open("calkit.yaml", "w") as f:
         calkit.ryaml.dump(ck_info, f)
     repo.git.add("calkit.yaml")
-    # Commit any necessary changes
-    typer.echo("Committing changes")
-    repo.git.commit(["-m", f"Import dataset {src_path}"])
-    # Run dvc pull
-    typer.echo("Running dvc pull")
-    subprocess.call(["dvc", "pull", dest_path])
+    if not no_commit:
+        # Commit any necessary changes
+        typer.echo("Committing changes")
+        repo.git.commit(["-m", f"Import dataset {src_path}"])
+    if not no_dvc_pull:
+        # Run dvc pull
+        typer.echo("Running dvc pull")
+        subprocess.call(["dvc", "pull", dest_path])
 
 
 @import_app.command(name="environment")

--- a/calkit/cli/import_.py
+++ b/calkit/cli/import_.py
@@ -107,9 +107,14 @@ def import_dataset(
         dvc_dir = os.path.dirname(dvc_fpath)
         os.makedirs(dvc_dir, exist_ok=True)
         # Update paths in .dvc file so they are relative to the DVC file
-        for n, out in enumerate(dvc_import["outs"]):
-            dvc_import["outs"][n]["path"] = os.path.relpath(
-                out["path"], dvc_dir
+        if len(dvc_import["outs"]) > 1:
+            for n, out in enumerate(dvc_import["outs"]):
+                dvc_import["outs"][n]["path"] = os.path.relpath(
+                    out["path"], dvc_dir
+                )
+        else:
+            dvc_import["outs"][0]["path"] = os.path.basename(
+                dvc_import["outs"][0]["path"]
             )
         typer.echo("Saving .dvc file")
         with open(dvc_fpath, "w") as f:

--- a/calkit/cli/import_.py
+++ b/calkit/cli/import_.py
@@ -65,7 +65,7 @@ def import_dataset(
     resp = calkit.cloud.get(
         f"/projects/{owner_name}/{project_name}/datasets/{path}"
     )
-    if not "dvc_import" in resp:
+    if "dvc_import" not in resp:
         raise ValueError("This file is not available to import with DVC")
     dvc_fpath = dest_path + ".dvc"
     dvc_dir = os.path.dirname(dvc_fpath)

--- a/calkit/cloud.py
+++ b/calkit/cloud.py
@@ -7,6 +7,7 @@ from functools import partial
 from typing import Literal
 
 import requests
+from requests.exceptions import HTTPError
 
 from . import config
 
@@ -82,7 +83,14 @@ def _request(
         headers=get_headers(headers),
         **kwargs,
     )
-    resp.raise_for_status()
+    try:
+        resp.raise_for_status()
+    except HTTPError as e:
+        try:
+            detail = resp.json()["detail"]
+        except Exception:
+            raise e
+        raise HTTPError(f"{resp.status_code}: {detail}")
     if as_json:
         return resp.json()
     else:

--- a/calkit/dvc.py
+++ b/calkit/dvc.py
@@ -91,13 +91,14 @@ def set_remote_auth(
     )
 
 
-def add_external_remote(owner_name: str, project_name: str):
+def add_external_remote(owner_name: str, project_name: str) -> dict:
     base_url = calkit.cloud.get_base_url()
     remote_url = f"{base_url}/projects/{owner_name}/{project_name}/dvc"
     remote_name = f"{get_app_name()}:{owner_name}/{project_name}"
     subprocess.call(["dvc", "remote", "add", "-f", remote_name, remote_url])
     subprocess.call(["dvc", "remote", "modify", remote_name, "auth", "custom"])
     set_remote_auth(remote_name)
+    return {"name": remote_name, "url": remote_url}
 
 
 def read_pipeline(wdir: str = ".") -> dict:

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -12,6 +12,7 @@ class _ImportedFromProject(BaseModel):
     project: str
     path: str | None = None
     git_rev: str | None = None
+    filter_paths: str | list[str] | None = None
 
 
 class _ImportedFromUrl(BaseModel):

--- a/calkit/models.py
+++ b/calkit/models.py
@@ -12,7 +12,7 @@ class _ImportedFromProject(BaseModel):
     project: str
     path: str | None = None
     git_rev: str | None = None
-    filter_paths: str | list[str] | None = None
+    filter_paths: list[str] | None = None
 
 
 class _ImportedFromUrl(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "requests",
   "typer",
   "uvicorn",
+  "tqdm>=4.67.1",
 ]
 description = "Reproducibility simplified."
 dynamic = ["version"]

--- a/uv.lock
+++ b/uv.lock
@@ -416,6 +416,7 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "pywin32", marker = "platform_system == 'Windows'" },
     { name = "requests" },
+    { name = "tqdm" },
     { name = "typer" },
     { name = "uvicorn" },
 ]
@@ -467,6 +468,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1" },
     { name = "pywin32", marker = "platform_system == 'Windows'" },
     { name = "requests" },
+    { name = "tqdm", specifier = ">=4.67.1" },
     { name = "typer" },
     { name = "uvicorn" },
 ]


### PR DESCRIPTION
## TODO

- [x] Allow importing a subset of a dataset, e.g., if we only want a few files out of it, but still want to keep track of the source, and don't want to take up our own cloud storage

Similar use case as https://github.com/calkit/calkit-cloud/issues/335