### PR TITLE
Add `check env-vars` command

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.4"
+__version__ = "0.20.5"
 
 from .core import *
 from . import git

--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -10,6 +10,7 @@ import subprocess
 from typing import Annotated
 
 import checksumdir
+import dotenv
 import typer
 
 import calkit
@@ -194,3 +195,32 @@ def check_conda_env(
         log_func=log_func,
         relaxed=relaxed,
     )
+
+
+@check_app.command(name="env-vars")
+def check_env_vars():
+    """Check that the project's required environmental variables exist."""
+    typer.echo("Checking project environmental variables")
+    dotenv.load_dotenv(dotenv_path=".env")
+    ck_info = calkit.load_calkit_info()
+    deps = ck_info.get("dependencies", [])
+    env_var_deps = {}
+    for d in deps:
+        if isinstance(d, dict):
+            name = list(d.keys())[0]
+            attrs = list(d.values())[0]
+            if attrs.get("kind") == "env-var":
+                env_var_deps[name] = attrs
+    for name, attrs in env_var_deps.items():
+        if name not in os.environ:
+            typer.echo(f"Missing env var '{name}'")
+            if "default" in attrs:
+                default = attrs["default"]
+            else:
+                default = None
+            value = typer.prompt(
+                f"Enter a value for {name}", default=default, type=str
+            )
+            dotenv.set_key(
+                dotenv_path=".env", key_to_set=name, value_to_set=value
+            )

--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -11,6 +11,7 @@ from typing import Annotated
 
 import checksumdir
 import dotenv
+import git
 import typer
 
 import calkit
@@ -224,3 +225,11 @@ def check_env_vars():
             dotenv.set_key(
                 dotenv_path=".env", key_to_set=name, value_to_set=value
             )
+    # Ensure that .env is ignored by git
+    repo = git.Repo()
+    if not repo.ignored(".env"):
+        typer.echo("Adding .env to .gitignore")
+        with open(".gitignore", "a") as f:
+            f.write("\n.env\n")
+    message = "✅ All set!"
+    typer.echo(message.encode("utf-8", errors="replace"))


### PR DESCRIPTION
If a project has environmental variable dependencies defined, this will iterate through them, and if they're not defined, prompt the user for them and add the supplied value to `.env`.

## TODO

- [x] Ensure `.env` is in `.gitignore`