### PR TITLE
Fix bug specifying `--wdir` for `xenv` with Docker

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.20.5"
+__version__ = "0.20.6"
 
 from .core import *
 from . import git

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -6,11 +6,10 @@ import csv
 import glob
 import os
 import platform as _platform
+import posixpath
 import subprocess
 import sys
 import time
-
-import posixpath
 
 import dotenv
 import dvc.repo

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import time
 
+import posixpath
+
 import dotenv
 import dvc.repo
 import git
@@ -835,7 +837,7 @@ def run_in_env(
     docker_wdir = env.get("wdir", "/work")
     docker_wdir_mount = docker_wdir
     if wdir is not None:
-        docker_wdir = os.path.join(docker_wdir, wdir)
+        docker_wdir = posixpath.join(docker_wdir, wdir)
     shell = env.get("shell", "sh")
     platform = env.get("platform")
     if env["kind"] == "docker":


### PR DESCRIPTION
Use `posixpath` instead of `os.path.join` so we use POSIX paths in the container.