### PR TITLE
Add ability to create automatic commit message if saving one path

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.21.2"
+__version__ = "0.21.3"
 
 from .core import *
 from . import git

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -13,3 +13,17 @@ def get_staged_files(path: str = None) -> list[str]:
     diff = repo.git.diff(cmd)
     paths = diff.split("\n")
     return paths
+
+
+def get_staged_files_with_status(path: str = None) -> list[dict]:
+    repo = git.Repo(path)
+    cmd = ["--staged", "--name-status"]
+    if path is not None:
+        cmd.append(path)
+    diff = repo.git.diff(cmd)
+    paths = diff.split("\n")
+    res = []
+    for path in paths:
+        status, p = path.split("\t")
+        res.append({"status": status, "path": p})
+    return res

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -346,3 +346,10 @@ def test_save(tmp_dir):
         f.write("sup")
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call(["calkit", "save", "-aM", "--no-push"])
+    with open("test3.txt", "w") as f:
+        f.write("sup2")
+    subprocess.check_call(
+        ["calkit", "save", "-am", "A unique message", "--no-push"]
+    )
+    last_commit_message = repo.head.commit.message.strip()
+    assert last_commit_message == "A unique message"

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -320,3 +320,22 @@ def test_status(tmp_dir):
     calkit.get_project_status_history(as_pydantic=False)
     with pytest.raises(subprocess.CalledProcessError):
         subprocess.check_call(["calkit", "new", "status", "very-cool"])
+
+
+def test_save(tmp_dir):
+    subprocess.check_call(["calkit", "init"])
+    repo = git.Repo()
+    assert repo.head.commit.message.strip() == "Initialize DVC"
+    with open("test.txt", "w") as f:
+        f.write("sup")
+    subprocess.check_call(["calkit", "save", "-aM", "--no-push"])
+    # Check that the last log message was "Add test.txt"
+    last_commit_message = repo.head.commit.message.strip()
+    assert last_commit_message == "Add test.txt"
+    # Update the file
+    with open("test.txt", "w") as f:
+        f.write("sup sup")
+    subprocess.check_call(["calkit", "save", "-aM", "--no-push"])
+    # Check that the last log message was "Update test.txt"
+    last_commit_message = repo.head.commit.message.strip()
+    assert last_commit_message == "Update test.txt"

--- a/calkit/tests/cli/test_main.py
+++ b/calkit/tests/cli/test_main.py
@@ -339,3 +339,10 @@ def test_save(tmp_dir):
     # Check that the last log message was "Update test.txt"
     last_commit_message = repo.head.commit.message.strip()
     assert last_commit_message == "Update test.txt"
+    # Check that we fail to save if there are two changed files
+    with open("test2.txt", "w") as f:
+        f.write("sup")
+    with open("test3.txt", "w") as f:
+        f.write("sup")
+    with pytest.raises(subprocess.CalledProcessError):
+        subprocess.check_call(["calkit", "save", "-aM", "--no-push"])


### PR DESCRIPTION
If one is continuously iterating on a single file, this can help speed things up

```sh
calkit save -aM
```

In the future it would be nice to have a VS Code extension that allows saving one file and creating an automated commit message for it (#216).