### PR TITLE
Allow defining prefix for Conda envs

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.21.3"
+__version__ = "0.21.4"
 
 from .core import *
 from . import git

--- a/calkit/check.py
+++ b/calkit/check.py
@@ -180,7 +180,7 @@ def check_reproducibility(
     if log_func is None:
         log_func = print
     try:
-        repo = git.Repo(wdir)
+        git.Repo(wdir)
         res["is_git_repo"] = True
     except InvalidGitRepositoryError:
         res["is_git_repo"] = False

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -905,7 +905,7 @@ def run_in_env(
                 fpath=env["path"],
                 platform=env.get("platform"),
                 deps=env.get("deps", []),
-                quiet=True,
+                quiet=not verbose,
             )
         shell_cmd = _to_shell_cmd(cmd)
         docker_cmd = [
@@ -951,7 +951,7 @@ def run_in_env(
             check_conda_env(
                 env_fpath=env["path"],
                 relaxed=relaxed_check,
-                quiet=True,
+                quiet=not verbose,
             )
         prefix = env.get("prefix")
         conda_cmd = ["conda", "run"]

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -949,9 +949,17 @@ def run_in_env(
             conda_env = calkit.ryaml.load(f)
         if not no_check:
             check_conda_env(
-                env_fpath=env["path"], relaxed=relaxed_check, quiet=True
+                env_fpath=env["path"],
+                relaxed=relaxed_check,
+                quiet=True,
             )
-        cmd = ["conda", "run", "-n", conda_env["name"]] + cmd
+        prefix = env.get("prefix")
+        conda_cmd = ["conda", "run"]
+        if prefix is not None:
+            conda_cmd += ["--prefix", prefix]
+        else:
+            conda_cmd += ["-n", conda_env["name"]]
+        cmd = conda_cmd + cmd
         if verbose:
             typer.echo(f"Running command: {cmd}")
         try:

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -953,10 +953,11 @@ def run_in_env(
                 relaxed=relaxed_check,
                 quiet=not verbose,
             )
+        # TODO: Prefix should only be in the env file or calkit.yaml, not both?
         prefix = env.get("prefix")
         conda_cmd = ["conda", "run"]
         if prefix is not None:
-            conda_cmd += ["--prefix", prefix]
+            conda_cmd += ["--prefix", os.path.abspath(prefix)]
         else:
             conda_cmd += ["-n", conda_env["name"]]
         cmd = conda_cmd + cmd

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -963,6 +963,9 @@ def new_conda_env(
     pip_packages: Annotated[
         list[str], typer.Option("--pip", help="Packages to install with pip.")
     ] = [],
+    prefix: Annotated[
+        str, typer.Option("--prefix", help="Prefix for environment location.")
+    ] = None,
     description: Annotated[
         str, typer.Option("--description", help="Description.")
     ] = None,
@@ -1003,6 +1006,8 @@ def new_conda_env(
     conda_env = dict(
         name=conda_name, channels=["conda-forge"], dependencies=packages
     )
+    if prefix is not None:
+        conda_env["prefix"] = prefix
     if pip_packages:
         conda_env["dependencies"].append(dict(pip=pip_packages))
     with open(path, "w") as f:
@@ -1010,6 +1015,8 @@ def new_conda_env(
     repo.git.add(path)
     typer.echo("Adding environment to calkit.yaml")
     env = dict(path=path, kind="conda")
+    if prefix is not None:
+        env["prefix"] = prefix
     if description is not None:
         env["description"] = description
     envs[name] = env

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1007,7 +1007,11 @@ def new_conda_env(
         name=conda_name, channels=["conda-forge"], dependencies=packages
     )
     if prefix is not None:
+        from calkit.cli.main import ignore
+
         conda_env["prefix"] = prefix
+        ignore(prefix, no_commit=True)
+        repo.git.add(".gitignore")
     if pip_packages:
         conda_env["dependencies"].append(dict(pip=pip_packages))
     with open(path, "w") as f:

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -225,8 +225,18 @@ def check_env(
         or not os.path.isfile(output_fpath)
     ):
         log_func(f"Exporting lock file to {output_fpath}")
+        env_export = json.loads(
+            subprocess.check_output(
+                [
+                    "conda",
+                    "env",
+                    "export",
+                    "-n",
+                    env_name,
+                    "--json",
+                ]
+            ).decode()
+        )
         with open(output_fpath, "w") as f:
-            _ = env_check.pop("mtime")
-            _ = env_check.pop("prefix")
-            ryaml.dump(env_check, f)
+            ryaml.dump(env_export, f)
     return res

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -112,8 +112,12 @@ def check_env(
         "--no-builds",
         "--json",
     ]
+    # Create with conda since newer mamba versions create a strange
+    # "Library" subdirectory, at least on Windows
+    create_cmd = ["conda", "env", "create", "-y", "-f", env_fpath]
     if prefix is not None:
         export_cmd += ["--prefix", prefix]
+        create_cmd += ["--prefix", prefix]
     else:
         export_cmd += ["-n", env_name]
     # Check if env even exists
@@ -122,11 +126,6 @@ def check_env(
         log_func(f"Environment {env_name} doesn't exist; creating")
         res.env_exists = False
         # Environment doesn't exist, so create it
-        # Create with conda since newer mamba versions create a strange
-        # "Library" subdirectory, at least on Windows
-        create_cmd = ["conda", "env", "create", "-y", "-f", env_fpath]
-        if prefix is not None:
-            create_cmd += ["--prefix", prefix]
         subprocess.check_call(create_cmd)
         env_needs_rebuild = False
         env_needs_export = True
@@ -205,7 +204,6 @@ def check_env(
     if env_needs_rebuild:
         res.env_needs_rebuild = True
         log_func(f"Rebuilding {env_name} since it does not match spec")
-        create_cmd = ["conda", "env", "create", "-y", "-f", env_fpath]
         subprocess.check_call(create_cmd)
         env_needs_export = True
     else:

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -91,6 +91,7 @@ def check_env(
         env_spec = ryaml.load(f)
     env_name = env_spec["name"]
     prefix = env_spec.get("prefix")
+    prefix_orig = prefix
     if prefix is not None:
         prefix = os.path.abspath(prefix)
         env_check_fpath = os.path.join(prefix, "env-export.yml")
@@ -239,6 +240,7 @@ def check_env(
         # Remove name if prefix is set, since that will be the prefix
         if prefix is not None:
             _ = env_export.pop("name")
+            env_export["prefix"] = prefix_orig
         with open(output_fpath, "w") as f:
             ryaml.dump(env_export, f)
     return res

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -75,9 +75,9 @@ def check_env(
     log_func(f"Checking conda env defined in {env_fpath}")
     res = EnvCheckResult()
     # Use mamba here because it's faster and produces less output
-    info = json.loads(subprocess.check_output(["mamba", "info", "--json"]))
-    base_env = info["base environment"]
-    envs_dir = os.path.join(base_env, "envs")
+    info = json.loads(subprocess.check_output(["conda", "info", "--json"]))
+    root_prefix = info["root_prefix"]
+    envs_dir = os.path.join(root_prefix, "envs")
     envs = json.loads(
         subprocess.check_output(["mamba", "env", "list", "--json"]).decode()
     )["envs"]
@@ -86,7 +86,7 @@ def check_env(
         os.path.basename(env) for env in envs if env.startswith(envs_dir)
     ]
     # Get a list of environments defined by prefix instead of name
-    env_prefixes = [e for e in envs if not e.startswith(base_env)]
+    env_prefixes = [e for e in envs if not e.startswith(root_prefix)]
     with open(env_fpath) as f:
         env_spec = ryaml.load(f)
     env_name = env_spec["name"]

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -236,6 +236,9 @@ def check_env(
         )
         # Remove prefix from env export since it will be an absolute path
         _ = env_export.pop("prefix")
+        # Remove name if prefix is set, since that will be the prefix
+        if prefix is not None:
+            _ = env_export.pop("name")
         with open(output_fpath, "w") as f:
             ryaml.dump(env_export, f)
     return res

--- a/calkit/tests/test_conda.py
+++ b/calkit/tests/test_conda.py
@@ -228,3 +228,18 @@ def test_check_prefix_env(tmp_dir, conda_env_prefix):
             "import requests",
         ]
     )
+    # Test that we can specify --wdir
+    os.makedirs("subdir")
+    subprocess.check_call(
+        [
+            "calkit",
+            "xenv",
+            "--wdir",
+            "subdir",
+            "-n",
+            "my-conda-env",
+            "python",
+            "-c",
+            "import requests",
+        ]
+    )

--- a/calkit/tests/test_conda.py
+++ b/calkit/tests/test_conda.py
@@ -207,3 +207,24 @@ def test_check_prefix_env(tmp_dir, conda_env_prefix):
     subprocess.check_call(
         ["calkit", "xenv", "-n", "my-conda-env", "python", "--version"]
     )
+    # Test that we can add a new dependency
+    with open("environment.yml") as f:
+        env = calkit.ryaml.load(f)
+    env["dependencies"].append("requests")
+    with open("environment.yml", "w") as f:
+        calkit.ryaml.dump(env, f)
+    res = check_env()
+    assert res.env_exists
+    assert res.env_needs_export
+    assert res.env_needs_rebuild
+    subprocess.check_call(
+        [
+            "calkit",
+            "xenv",
+            "-n",
+            "my-conda-env",
+            "python",
+            "-c",
+            "import requests",
+        ]
+    )

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -236,6 +236,13 @@ The new Conda environment spec will be written to `environment.yml`
 by default,
 which can be controlled with the `--path` option.
 
+A prefix for the environment can be specified to keep all packages under the
+project directory, e.g., by adding `--prefix .conda-envs/my-conda-env`.
+If this option is omitted, the environment will become part of Conda's
+system-wide collection of environments with a name like
+`{project_name}-{env_name}`,
+where the project name is added to avoid conflicts.
+
 Similar to other environment types,
 any time a command is executed with `calkit xenv`,
 this environment will be checked and created or updated as necessary.


### PR DESCRIPTION
Resolves #272 

## TODO

- [x] Add test for this
- [x] Test on Windows
- [x] Make this work when using `--wdir` with `xenv`
- [ ] Can we avoid defining prefix in both `calkit.yaml` and the env spec file? -- `conda.check_env` only uses the env spec file, so the prefix needs to be written in there. Technically we don't use the one in `calkit.yaml` for anything important, though other env types use their `prefix` attribute, so maybe it's okay to keep there. Changing it after the fact could be confusing though since it lives in two places and can be inconsistent.