### PR TITLE
Use UTF-8 encoding to apply Overleaf diff to prevent Unicode error on Windows

### DIFF
--- a/calkit/cli/overleaf.py
+++ b/calkit/cli/overleaf.py
@@ -389,6 +389,7 @@ def sync(
                     ["git", "apply", "--directory", wdir, "-"],
                     input=diff,
                     text=True,
+                    encoding="utf-8"
                 )
                 if process.returncode != 0:
                     raise_error("Failed to apply diff")


### PR DESCRIPTION
Solves #387 