### PR TITLE
Add function to declare notebook

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.24.9"
+__version__ = "0.25.0"
 
 from .core import *  # noqa: F403, I001
 from . import git  # noqa: F401
@@ -15,3 +15,4 @@ from . import check  # noqa: F401
 from . import github  # noqa: F401
 from . import zenodo  # noqa: F401
 from . import releases  # noqa: F401
+from .notebooks import declare_notebook  # noqa: F401

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -709,7 +709,7 @@ def run(
     no_commit: Annotated[bool, typer.Option("--no-commit")] = False,
     no_run_cache: Annotated[bool, typer.Option("--no-run-cache")] = False,
 ):
-    """Check dependencies, run DVC pipeline, and update Calkit objects."""
+    """Check dependencies and run the pipeline."""
     os.environ["CALKIT_PIPELINE_RUNNING"] = "1"
     dotenv.load_dotenv(dotenv_path=".env", verbose=verbose)
     # First check any system-level dependencies exist

--- a/calkit/models/__init__.py
+++ b/calkit/models/__init__.py
@@ -1,2 +1,3 @@
 from .core import *  # noqa: F403, I001
 from . import pipeline  # noqa: F401, F403
+from . import io  # noqa: F401, F403

--- a/calkit/models/core.py
+++ b/calkit/models/core.py
@@ -85,23 +85,28 @@ class Environment(BaseModel):
     default: bool | None = None
 
 
+class CondaEnvironment(Environment):
+    kind: Literal["conda"] = "conda"
+    prefix: str | None = None
+
+
 class VenvEnvironment(Environment):
-    kind: Literal["venv"]
+    kind: Literal["venv"] = "venv"
     prefix: str
 
 
 class UvVenvEnvironment(Environment):
-    kind: Literal["uv-venv"]
+    kind: Literal["uv-venv"] = "uv-venv"
     prefix: str
 
 
 class PixiEnvironment(Environment):
-    kind: Literal["pixi"]
+    kind: Literal["pixi"] = "pixi"
     name: str | None = None
 
 
 class DockerEnvironment(Environment):
-    kind: Literal["docker"]
+    kind: Literal["docker"] = "docker"
     image: str
     layers: list[str] | None = None
     shell: Literal["bash", "sh"] = "sh"
@@ -109,12 +114,12 @@ class DockerEnvironment(Environment):
 
 
 class REnvironment(Environment):
-    kind: Literal["renv"]
+    kind: Literal["renv"] = "renv"
     prefix: str
 
 
 class SSHEnvironment(BaseModel):
-    kind: Literal["ssh"]
+    kind: Literal["ssh"] = "ssh"
     host: str
     user: str
     wdir: str

--- a/calkit/models/io.py
+++ b/calkit/models/io.py
@@ -5,6 +5,10 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict
 
 
+class InputsFromStageOutputs(BaseModel):
+    from_stage_outputs: str
+
+
 class Input(BaseModel):
     kind: Literal["path", "python-object", "file-segment", "database-table"]
 

--- a/calkit/models/io.py
+++ b/calkit/models/io.py
@@ -1,0 +1,49 @@
+"""Models for inputs and outputs."""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Input(BaseModel):
+    kind: Literal["path", "python-object", "file-segment", "database-table"]
+
+
+class PathInput(Input):
+    kind: Literal["path"]
+    path: str
+
+
+class PythonObjectInput(Input):
+    kind: Literal["python-object"]
+    module: str
+    object_name: str
+
+
+class FileSegmentInput(Input):
+    kind: Literal["file-segment"]
+    path: str
+    start_line: int
+    end_line: int
+
+
+class DatabaseTableInput(Input):
+    kind: Literal["database-table"]
+    database_uri: str
+    database_name: str | None = None
+    table_name: str
+
+
+class PathOutput(BaseModel):
+    path: str
+    storage: Literal["git", "dvc"] | None = "dvc"
+    delete_before_run: bool = True
+    # Do not allow extra keys
+    model_config = ConfigDict(extra="forbid")
+
+
+class DatabaseTableOutput(BaseModel):
+    kind: Literal["database-table"]
+    uri: str
+    database_name: str | None = None
+    table_name: str

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -8,6 +8,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Discriminator
 from typing_extensions import Annotated
 
+from calkit.models.io import PathOutput
 from calkit.models.iteration import (
     ParameterIteration,
     ParametersType,
@@ -19,52 +20,8 @@ from calkit.notebooks import (
 )
 
 
-class Input(BaseModel):
-    kind: Literal["path", "python-object", "file-segment", "database-table"]
-
-
-class PathInput(Input):
-    kind: Literal["path"]
-    path: str
-
-
-class PythonObjectInput(Input):
-    kind: Literal["python-object"]
-    module: str
-    object_name: str
-
-
-class FileSegmentInput(Input):
-    kind: Literal["file-segment"]
-    path: str
-    start_line: int
-    end_line: int
-
-
-class DatabaseTableInput(Input):
-    kind: Literal["database-table"]
-    database_uri: str
-    database_name: str | None = None
-    table_name: str
-
-
 class InputsFromStageOutputs(BaseModel):
     from_stage_outputs: str
-
-
-class PathOutput(BaseModel):
-    path: str
-    storage: Literal["git", "dvc"] | None = "dvc"
-    delete_before_run: bool = True
-    # Do not allow extra keys
-    model_config = ConfigDict(extra="forbid")
-
-
-class DatabaseTableOutput(BaseModel):
-    kind: Literal["database-table"]
-    uri: str
-    database_name: str | None = None
-    table_name: str
 
 
 class StageIteration(BaseModel):

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -8,7 +8,7 @@ from typing import Literal
 from pydantic import BaseModel, ConfigDict, Discriminator
 from typing_extensions import Annotated
 
-from calkit.models.io import PathOutput
+from calkit.models.io import InputsFromStageOutputs, PathOutput
 from calkit.models.iteration import (
     ParameterIteration,
     ParametersType,
@@ -18,10 +18,6 @@ from calkit.notebooks import (
     get_cleaned_notebook_path,
     get_executed_notebook_path,
 )
-
-
-class InputsFromStageOutputs(BaseModel):
-    from_stage_outputs: str
 
 
 class StageIteration(BaseModel):

--- a/calkit/notebooks.py
+++ b/calkit/notebooks.py
@@ -4,6 +4,8 @@ import os
 from pathlib import PurePosixPath
 from typing import Literal
 
+from calkit.models.io import PathOutput
+
 
 def get_executed_notebook_path(
     notebook_path: str, to: Literal["html", "notebook"], as_posix: bool = True
@@ -29,3 +31,27 @@ def get_cleaned_notebook_path(path: str, as_posix: bool = True) -> str:
     if as_posix:
         p = PurePosixPath(p).as_posix()
     return p
+
+
+def declare_notebook(
+    path: str,
+    stage_name: str,
+    environment_name: str,
+    inputs: list[str] = [],
+    outputs: list[str | PathOutput] = [],
+    title: str | None = None,
+    description: str | None = None,
+    html_storage: Literal["git", "dvc"] | None = "dvc",
+    executed_ipynb_storage: Literal["git", "dvc"] | None = "dvc",
+    cleaned_ipynb_storage: Literal["git", "dvc"] | None = "git",
+):
+    """Declare a notebook as part of the current project."""
+    # TODO: If pipeline is running, just check that we are running in the
+    # correct environment and that the notebook is in the correct location?
+    # TODO: Don't do anything if the pipeline is currently running, since this
+    # is meant to be run outside of the pipeline
+    # Ensure we find the project root (where .git is) and work from there
+    # TODO: Check that this content exists in this notebook
+    # TODO: Check that the specified environment exists
+    # TODO: Change to the correct working directory?
+    pass

--- a/calkit/notebooks.py
+++ b/calkit/notebooks.py
@@ -4,7 +4,10 @@ import os
 from pathlib import PurePosixPath
 from typing import Literal
 
-from calkit.models.io import PathOutput
+import git
+
+import calkit
+from calkit.models.io import InputsFromStageOutputs, PathOutput
 
 
 def get_executed_notebook_path(
@@ -37,21 +40,113 @@ def declare_notebook(
     path: str,
     stage_name: str,
     environment_name: str,
-    inputs: list[str] = [],
+    inputs: list[str | InputsFromStageOutputs] = [],
     outputs: list[str | PathOutput] = [],
+    always_run: bool = False,
     title: str | None = None,
     description: str | None = None,
     html_storage: Literal["git", "dvc"] | None = "dvc",
     executed_ipynb_storage: Literal["git", "dvc"] | None = "dvc",
     cleaned_ipynb_storage: Literal["git", "dvc"] | None = "git",
 ):
-    """Declare a notebook as part of the current project."""
-    # TODO: If pipeline is running, just check that we are running in the
-    # correct environment and that the notebook is in the correct location?
-    # TODO: Don't do anything if the pipeline is currently running, since this
-    # is meant to be run outside of the pipeline
-    # Ensure we find the project root (where .git is) and work from there
-    # TODO: Check that this content exists in this notebook
-    # TODO: Check that the specified environment exists
+    """Declare a notebook as part of the current project.
+
+    If this function is called as part of a running pipeline, it will fail
+    if anything has changed about the pipeline declaration, then prompt the
+    user to rerun.
+    """
+    from calkit.models.pipeline import JupyterNotebookStage, Pipeline
+
+    # Detect the project root directory so we ensure calkit.yaml lives there
+    repo = git.Repo(search_parent_directories=True)
+    wdir = repo.working_dir
+    if not os.path.isfile(os.path.join(wdir, path)):
+        raise FileNotFoundError(
+            f"Notebook '{path}' does not exist in the project directory"
+        )
+    # TODO: If pipeline is running, check that we are running in the
+    # correct environment
+    pipeline_running = os.getenv("CALKIT_PIPELINE_RUNNING", "0") == "1"
+    ck_info = calkit.load_calkit_info(wdir=str(wdir))
+    envs = ck_info.get("environments", {})
+    if environment_name not in envs:
+        raise ValueError(
+            f"Environment '{environment_name}' does not exist in calkit.yaml"
+        )
+    pipeline_dict = ck_info.get("pipeline", {})
+    if "stages" not in pipeline_dict:
+        pipeline_dict["stages"] = {}
+    pipeline = Pipeline.model_validate(pipeline_dict)
+    new_stage = JupyterNotebookStage(
+        notebook_path=path,
+        environment=environment_name,
+        inputs=inputs,
+        outputs=outputs,
+        always_run=always_run,
+        html_storage=html_storage,
+        executed_ipynb_storage=executed_ipynb_storage,
+        cleaned_ipynb_storage=cleaned_ipynb_storage,
+    )
+    stages = pipeline.stages
+    must_be_rerun = False
+    # Check to see if we're mutating an existing stage
+    if pipeline_running and stage_name in stages:
+        # If the pipeline is running, we can't change the stage
+        existing_stage = stages[stage_name]
+        if existing_stage != new_stage:
+            must_be_rerun = True
+    new_stage_dump = new_stage.model_dump()
+    new_stage_dict = {
+        "kind": "jupyter-notebook",
+        "notebook_path": path,
+        "environment": environment_name,
+    }
+    if inputs:
+        new_stage_dict["inputs"] = new_stage_dump["inputs"]
+    if outputs:
+        new_stage_dict["outputs"] = new_stage_dump["outputs"]
+    if always_run:
+        new_stage_dict["always_run"] = always_run
+    new_stage_dict.update(
+        {
+            "html_storage": html_storage,
+            "executed_ipynb_storage": executed_ipynb_storage,
+            "cleaned_ipynb_storage": cleaned_ipynb_storage,
+        }
+    )
+    pipeline_dict["stages"][stage_name] = new_stage_dict
+    # Update existing notebook if it exists, else append
+    notebooks = ck_info.get("notebooks", [])
+    updated = False
+    for notebook in notebooks:
+        if notebook.get("path") == path:
+            notebook.update(
+                {
+                    "title": title,
+                    "description": description,
+                    "stage": stage_name,
+                }
+            )
+            updated = True
+            break
+    if not updated:
+        notebooks.append(
+            {
+                "path": path,
+                "title": title,
+                "description": description,
+                "stage": stage_name,
+            }
+        )
+    # Write calkit.yaml
+    fpath = os.path.join(wdir, "calkit.yaml")
+    ck_info["pipeline"] = pipeline_dict
+    ck_info["notebooks"] = notebooks
+    with open(fpath, "w") as f:
+        calkit.ryaml.dump(ck_info, f)
+    if must_be_rerun:
+        raise RuntimeError(
+            f"Notebook stage '{stage_name}' was modified while the pipeline "
+            "was running; please run the pipeline again"
+        )
     # TODO: Change to the correct working directory?
-    pass

--- a/calkit/notebooks.py
+++ b/calkit/notebooks.py
@@ -64,8 +64,6 @@ def declare_notebook(
         raise FileNotFoundError(
             f"Notebook '{path}' does not exist in the project directory"
         )
-    # TODO: If pipeline is running, check that we are running in the
-    # correct environment
     pipeline_running = os.getenv("CALKIT_PIPELINE_RUNNING", "0") == "1"
     ck_info = calkit.load_calkit_info(wdir=str(wdir))
     envs = ck_info.get("environments", {})
@@ -73,6 +71,8 @@ def declare_notebook(
         raise ValueError(
             f"Environment '{environment_name}' does not exist in calkit.yaml"
         )
+    # TODO: Check that we are running in the correct environment
+    # This could be tricky depending on what type of environment it is
     pipeline_dict = ck_info.get("pipeline", {})
     if "stages" not in pipeline_dict:
         pipeline_dict["stages"] = {}

--- a/calkit/notebooks.py
+++ b/calkit/notebooks.py
@@ -106,13 +106,13 @@ def declare_notebook(
     if outputs:
         new_stage_dict["outputs"] = new_stage_dump["outputs"]
     if always_run:
-        new_stage_dict["always_run"] = always_run
+        new_stage_dict["always_run"] = always_run  # type: ignore
     new_stage_dict.update(
         {
             "html_storage": html_storage,
             "executed_ipynb_storage": executed_ipynb_storage,
             "cleaned_ipynb_storage": cleaned_ipynb_storage,
-        }
+        }  # type: ignore
     )
     pipeline_dict["stages"][stage_name] = new_stage_dict
     # Update existing notebook if it exists, else append


### PR DESCRIPTION
The goal here is to make it easier for users to create their pipeline without directly writing YAML. If they started with a notebook, they can just declare it with this function and it will run if they call `calkit run`.

## TODO

- [ ] Users should be able to declare environments idempotently from a notebook?
- [ ] Users should be able to initialize a project idempotently from a notebook?