### PR TITLE
Try to use lock files to recreate venvs

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.26.3"
+__version__ = "0.26.4"
 
 from .core import *  # noqa: F403, I001
 from . import git  # noqa: F401

--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -467,10 +467,12 @@ def check_venv(
     if lock_dir:
         os.makedirs(lock_dir, exist_ok=True)
     # If the lock file exists, try to install with that
-    dep_file_path = lock_fpath or path
+    dep_file_txt = f"-r {path}"
+    if os.path.isfile(lock_fpath):
+        dep_file_txt += f" -r {lock_fpath}"
     check_cmd = (
         f"{activate_cmd} "
-        f"&& {pip_cmd} install {pip_install_args} -r {dep_file_path} "
+        f"&& {pip_cmd} install {pip_install_args} {dep_file_txt} "
         f"&& {pip_freeze_cmd} > {lock_fpath} "
         "&& deactivate"
     )

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -874,7 +874,7 @@ def run(
     ] = False,
     no_log: Annotated[
         bool,
-        typer.Option("--no-log", help="Do not log the run."),
+        typer.Option("--no-log", "-l", help="Do not log the run."),
     ] = False,
     save_after_run: Annotated[
         bool,
@@ -893,16 +893,17 @@ def run(
     if not quiet:
         typer.echo("Getting system information")
     system_info = calkit.get_system_info()
-    # Save the system to .calkit/systems
-    if verbose:
-        typer.echo("Saving system information:")
-        typer.echo(system_info)
-    sysinfo_fpath = os.path.join(
-        ".calkit", "systems", system_info["id"] + ".json"
-    )
-    os.makedirs(os.path.dirname(sysinfo_fpath), exist_ok=True)
-    with open(sysinfo_fpath, "w") as f:
-        json.dump(system_info, f, indent=2)
+    if not no_log:
+        # Save the system to .calkit/systems
+        if verbose:
+            typer.echo("Saving system information:")
+            typer.echo(system_info)
+        sysinfo_fpath = os.path.join(
+            ".calkit", "systems", system_info["id"] + ".json"
+        )
+        os.makedirs(os.path.dirname(sysinfo_fpath), exist_ok=True)
+        with open(sysinfo_fpath, "w") as f:
+            json.dump(system_info, f, indent=2)
     # First check any system-level dependencies exist
     if not quiet:
         typer.echo("Checking system-level dependencies")

--- a/calkit/cli/main.py
+++ b/calkit/cli/main.py
@@ -1190,6 +1190,12 @@ def run_in_env(
                 ),
                 platform=env.get("platform"),
                 deps=env.get("deps", []),
+                env_vars=env.get("env_vars", []),
+                ports=env.get("ports", []),
+                gpus=env.get("gpus"),
+                user=env.get("user"),
+                wdir=env.get("wdir"),
+                args=env.get("args", []),
                 quiet=not verbose,
             )
         shell_cmd = _to_shell_cmd(cmd)

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -17,9 +17,21 @@ from calkit import ryaml
 
 
 def _check_single(req: str, actual: str, conda: bool = False) -> bool:
-    """Helper function for checking actual versions against requirements."""
-    req_name = re.split("[=<>]", req)[0]
-    req_spec = req.removeprefix(req_name)
+    """Helper function for checking actual versions against requirements.
+
+    Note that this also doesn't check optional dependencies.
+    """
+    # If this is a Git version, we can't check it
+    # TODO: Clone Git repos to check?
+    if "@git" in req:
+        warnings.warn(f"Cannot check Git version for {req}")
+        req = req.split("@git")[0]
+    req_name = re.split("[=<>]", req)[0].strip()
+    req_spec = req.removeprefix(req_name).strip().replace(" ", "")
+    if "[" in req_name:
+        warnings.warn(f"Cannot check optional dependencies for {req_name}")
+        # Remove optional dependencies
+        req_name = req_name.split("[")[0].strip()
     if conda and req_spec.startswith("="):
         req_spec = "=" + req_spec
         if not req_spec.endswith(".*"):

--- a/calkit/tests/cli/test_check.py
+++ b/calkit/tests/cli/test_check.py
@@ -1,0 +1,45 @@
+"""Tests for ``calkit.cli.check``."""
+
+import shutil
+import subprocess
+
+
+def test_check_venv(tmp_dir):
+    with open("reqs.txt", "w") as f:
+        f.write("requests")
+    subprocess.check_call(
+        ["calkit", "check", "venv", "reqs.txt", "-o", "lock.txt"]
+    )
+    # Now check that we can install from the lock file
+    shutil.rmtree(".venv")
+    subprocess.check_call(
+        ["calkit", "check", "venv", "reqs.txt", "-o", "lock.txt"]
+    )
+    with open("lock.txt") as f:
+        lock_txt = f.read()
+    # Now check that if we add a requirement, the env is rebuilt
+    assert "polars" not in lock_txt
+    with open("reqs.txt", "w") as f:
+        f.write("requests\npolars")
+    subprocess.check_call(
+        ["calkit", "check", "venv", "reqs.txt", "-o", "lock.txt"]
+    )
+    with open("lock.txt") as f:
+        lock_txt = f.read()
+    assert "polars" in lock_txt
+    # Now confirm that if we check the env again, nothing happens
+    subprocess.check_call(
+        ["calkit", "check", "venv", "reqs.txt", "-o", "lock.txt"]
+    )
+    with open("lock.txt") as f:
+        lock_txt_2 = f.read()
+    assert lock_txt == lock_txt_2
+    # Now check that if we pin a version in reqs.txt, we rebuild
+    with open("reqs.txt", "w") as f:
+        f.write("requests\npolars==1.0.0")
+    subprocess.check_call(
+        ["calkit", "check", "venv", "reqs.txt", "-o", "lock.txt"]
+    )
+    with open("lock.txt") as f:
+        lock_txt_3 = f.read()
+    assert "polars==1.0.0" in lock_txt_3


### PR DESCRIPTION
Related to #400 

Resolves #229 

Resolves #426, though it doesn't fully check the dependency versions when they have optional dependencies or Git versions. 

## TODO

- [x] Add test for this condition
- [ ] Do this for Conda envs? Maybe should be a follow-on issue.