### PR TITLE
Allow creating a project in the cloud when it exists locally

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.28.3"
+__version__ = "0.28.4"
 
 from .core import *  # noqa: F403, I001
 from . import git  # noqa: F401


### PR DESCRIPTION
Resolves #498 

This is currently only possible on calkit.io by entering the Git repo URL after the title and description. Now we can do it via CLI.

To use, run inside a project directory:

```sh
calkit new project . --cloud
```