### PR TITLE
Allow specifying latexmkrc path for LaTeX stages

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.30.1"
+__version__ = "0.30.2"
 
 from .core import *  # noqa: F403, I001
 from . import git  # noqa: F401

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -211,13 +211,16 @@ class PythonScriptStage(Stage):
 class LatexStage(Stage):
     kind: Literal["latex"] = "latex"
     target_path: str
+    latexmkrc_path: str | None = None
     verbose: bool = False
     force: bool = False
     synctex: bool = True
 
     @property
     def dvc_cmd(self) -> str:
-        cmd = f"{self.xenv_cmd} latexmk -cd -interaction=nonstopmode"
+        cmd = f"{self.xenv_cmd} latexmk -cd -norc -interaction=nonstopmode"
+        if self.latexmkrc_path is not None:
+            cmd += f" -r {self.latexmkrc_path}"
         if not self.verbose:
             cmd += " -silent"
         if self.force:
@@ -229,7 +232,11 @@ class LatexStage(Stage):
 
     @property
     def dvc_deps(self) -> list[str]:
-        return [self.target_path] + super().dvc_deps
+        deps = [self.target_path]
+        if self.latexmkrc_path is not None:
+            deps.append(self.latexmkrc_path)
+        deps += super().dvc_deps
+        return deps
 
     @property
     def dvc_outs(self) -> list[str | dict]:

--- a/calkit/tests/cli/test_new.py
+++ b/calkit/tests/cli/test_new.py
@@ -579,7 +579,8 @@ def test_new_latex_stage(tmp_dir):
     pipeline = calkit.dvc.read_pipeline()
     assert pipeline["stages"]["build-paper"]["cmd"] == (
         "calkit xenv -n tex --no-check -- "
-        "latexmk -cd -interaction=nonstopmode -silent -synctex=1 -pdf paper.tex"
+        "latexmk -cd -norc -interaction=nonstopmode -silent -synctex=1 "
+        "-pdf paper.tex"
     )
     assert set(pipeline["stages"]["build-paper"]["deps"]) == set(
         ["paper.tex", ".calkit/env-locks/tex.json"]

--- a/calkit/tests/models/test_pipeline.py
+++ b/calkit/tests/models/test_pipeline.py
@@ -63,6 +63,14 @@ def test_latexstage():
     assert " -silent " not in s.dvc_cmd
     assert "my-paper.tex" in s.dvc_deps
     assert "my-paper.pdf" in s.dvc_outs
+    s = LatexStage(
+        name="something",
+        environment="tex",
+        target_path="my-paper.tex",
+        latexmkrc_path="test/latexmkrc",
+    )
+    assert "test/latexmkrc" in s.dvc_deps
+    assert "-r test/latexmkrc" in s.dvc_cmd
 
 
 def test_jupyternotebookstage():


### PR DESCRIPTION
Resolves #533 

Note that we will not pick up on one automatically. It needs to be specified explicitly so we can track it as a DVC dependency.