### PR TITLE
Tag image when pulled via digest

### DIFF
--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.31.2"
+__version__ = "0.31.3"
 
 from .core import *  # noqa: F403, I001
 from . import git  # noqa: F401


### PR DESCRIPTION
This was causing a failure when the Docker image with the tag didn't already exist but we had a digest to pull with.