### PR TITLE
Fix #723: Use local .gitignore in overleaf folder

### DIFF
--- a/calkit/cli/overleaf.py
+++ b/calkit/cli/overleaf.py
@@ -170,7 +170,6 @@ def import_publication(
     ] = False,
 ):
     """Import a publication from an Overleaf project."""
-    from calkit.cli.main import ignore as git_ignore
     from calkit.cli.new import new_latex_stage
 
     # First check that the user has an Overleaf token set
@@ -200,7 +199,10 @@ def import_publication(
     # otherwise pull
     overleaf_dir = os.path.join(".calkit", "overleaf")
     os.makedirs(overleaf_dir, exist_ok=True)
-    git_ignore(overleaf_dir, no_commit=no_commit)
+    # Write .gitignore in overleaf folder to ignore all contents
+    gitignore_path = os.path.join(overleaf_dir, ".gitignore")
+    with open(gitignore_path, "w") as f:
+        f.write("*\n")
     overleaf_project_dir = os.path.join(overleaf_dir, overleaf_project_id)
     git_clone_url = calkit.overleaf.get_git_remote_url(
         project_id=overleaf_project_id, token=overleaf_token
@@ -687,3 +689,4 @@ def get_status(
             typer.echo("Changed files:")
             for p in status["diff_files"]:
                 print_path(p, "red")
+


### PR DESCRIPTION
## Summary

Instead of adding `.calkit/overleaf` to the project-level `.gitignore`, this change creates a `.gitignore` file directly in the `.calkit/overleaf` folder with just `*` in it.

## Approach

- Removed the import of `ignore as git_ignore` from `calkit.cli.main`
- Replaced the `git_ignore(overleaf_dir, ...)` call with simple file write that creates `.calkit/overleaf/.gitignore` containing `*`

This approach is cleaner because:
1. It keeps the project-level `.gitignore` simpler
2. The ignore rule is self-contained within the overleaf folder
3. No need to commit changes to the project's `.gitignore`

## Files Changed

- `calkit/cli/overleaf.py`

## Related Issue

Fixes #723
