### PR TITLE
Rationalize conda env name handling

### DIFF
--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -309,6 +309,13 @@ def check_environment(
             quiet=not verbose,
         )
     elif env["kind"] == "conda":
+        project_name = ck_info.get("name")
+        if project_name is None:
+            project_name = os.path.basename(os.getcwd())
+        expected_conda_name = calkit.conda.default_conda_env_name(
+            env_name,
+            project_name,
+        )
         lock_fpath = get_env_lock_fpath(
             env=env, env_name=env_name, as_posix=False
         )
@@ -323,6 +330,7 @@ def check_environment(
             output_fpath=lock_fpath,
             alt_lock_fpaths_delete=[str(legacy_lock_fpath)],
             alt_lock_fpaths=alt_lock_fpaths,
+            expected_name=expected_conda_name,
             relaxed=True,  # TODO: Add option?
             quiet=not verbose,
         )
@@ -984,6 +992,17 @@ def check_conda_env(
     quiet: Annotated[
         bool, typer.Option("--quiet", "-q", help="Be quiet.")
     ] = False,
+    auto_sync_name: Annotated[
+        bool,
+        typer.Option(
+            "--auto-sync-name/--no-auto-sync-name",
+            help=(
+                "Automatically update the 'name' in the conda spec file "
+                "to the expected canonical name when they differ."
+            ),
+        ),
+    ] = True,
+    expected_name: str | None = None,
 ) -> None:
     log_func: Callable[..., None]
     if quiet:
@@ -999,6 +1018,8 @@ def check_conda_env(
             log_func=log_func,
             relaxed=relaxed,
             verbose=not quiet,
+            expected_name=expected_name,
+            auto_sync_name=auto_sync_name,
         )
     except Exception as e:
         raise_error(f"Failed to check conda environment: {e}")

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -1141,18 +1141,6 @@ def new_conda_env(
         list[str] | None,
         typer.Argument(help="Packages to include in the environment."),
     ] = None,
-    conda_name: Annotated[
-        str | None,
-        typer.Option(
-            "--conda-name",
-            help=(
-                "Name to use in the Conda environment file, if desired. "
-                "Will be automatically generated if not provided. "
-                "Note that these should be unique since Conda environments are "
-                "a system-wide collection."
-            ),
-        ),
-    ] = None,
     path: Annotated[
         str, typer.Option("--path", help="Environment YAML file path.")
     ] = "environment.yml",
@@ -1203,11 +1191,10 @@ def new_conda_env(
             f"Environment with name {name} already exists "
             "(use -f to overwrite)"
         )
-    if conda_name is None:
-        project_name = ck_info.get("name")
-        if project_name is None:
-            project_name = os.path.basename(os.getcwd())
-        conda_name = calkit.to_kebab_case(project_name) + "-" + name
+    project_name = ck_info.get("name")
+    if project_name is None:
+        project_name = os.path.basename(os.getcwd())
+    conda_name = calkit.conda.default_conda_env_name(name, project_name)
     if packages is not None:
         assert isinstance(packages, list)
         # Write environment to path

--- a/calkit/conda.py
+++ b/calkit/conda.py
@@ -259,6 +259,11 @@ class EnvCheckResult(BaseModel):
     env_needs_rebuild: bool | None = None
 
 
+def default_conda_env_name(calkit_env_name: str, project_name: str) -> str:
+    """Create the default conda env name from project + Calkit env name."""
+    return calkit.to_kebab_case(project_name) + "-" + calkit_env_name
+
+
 def check_env(
     env_fpath: str = "environment.yml",
     log_func=None,
@@ -267,6 +272,8 @@ def check_env(
     alt_lock_fpaths_delete: list[str] = [],
     relaxed: bool = False,
     verbose: bool = True,
+    expected_name: str | None = None,
+    auto_sync_name: bool = True,
 ) -> EnvCheckResult:
     """Check that a conda environment matches its spec.
 
@@ -305,6 +312,33 @@ def check_env(
     elif output_fpath and os.path.isfile(output_fpath):
         lock_to_use_for_creation = output_fpath
         log_func(f"Using existing lock file for creation: {output_fpath}")
+    with open(env_fpath) as f:
+        env_spec = ryaml.load(f)
+    env_name = env_spec["name"]
+    prefix = env_spec.get("prefix")
+    if (
+        expected_name is not None
+        and prefix is None
+        and env_name != expected_name
+    ):
+        if auto_sync_name:
+            old_name = env_name
+            env_spec["name"] = expected_name
+            with open(env_fpath, "w") as f:
+                ryaml.dump(env_spec, f)
+            env_name = expected_name
+            log_func(
+                "Updated conda env spec name from "
+                f"'{old_name}' to '{expected_name}' in {env_fpath}"
+            )
+        else:
+            raise ValueError(
+                "Conda environment name mismatch: "
+                f"spec file has '{env_name}' but Calkit expects "
+                f"'{expected_name}'. "
+                "Update the 'name' in the conda env spec to match the "
+                "Calkit naming convention."
+            )
     res = EnvCheckResult()
     if verbose:
         log_func("Getting conda info")
@@ -331,10 +365,6 @@ def check_env(
     ]
     # Get a list of environments defined by prefix instead of name
     env_prefixes = [e for e in envs if not e.startswith(root_prefix)]
-    with open(env_fpath) as f:
-        env_spec = ryaml.load(f)
-    env_name = env_spec["name"]
-    prefix = env_spec.get("prefix")
     prefix_orig = prefix
     if prefix is not None:
         prefix = os.path.abspath(prefix)
@@ -363,6 +393,25 @@ def check_env(
     create_file = (
         lock_to_use_for_creation if lock_to_use_for_creation else env_fpath
     )
+    if (
+        create_file != env_fpath
+        and expected_name is not None
+        and prefix is None
+    ):
+        try:
+            with open(create_file) as f:
+                lock_spec = ryaml.load(f)
+            lock_name = (
+                lock_spec.get("name") if isinstance(lock_spec, dict) else None
+            )
+        except Exception:
+            lock_name = None
+        if lock_name and lock_name != expected_name:
+            log_func(
+                "Ignoring lock file for environment creation because lock name "
+                f"'{lock_name}' does not match expected '{expected_name}'"
+            )
+            create_file = env_fpath
     create_cmd = [conda_exe, "env", "create", "-y", "-f", create_file]
     if prefix is not None:
         export_cmd += ["--prefix", prefix]

--- a/calkit/tests/test_conda.py
+++ b/calkit/tests/test_conda.py
@@ -13,6 +13,7 @@ from calkit.conda import (
     _get_pip_dependency_list,
     _split_env_dependencies,
     check_env,
+    default_conda_env_name,
 )
 
 ENV_NAME = "main"
@@ -61,6 +62,34 @@ def test_get_pip_dependency_list():
     pip_deps = _get_pip_dependency_list(dependencies)
     assert pip_deps == ["sqlalchemy==2.0.39"]
     assert dependencies[-1]["pip"] == ["sqlalchemy==2.0.39"]
+
+
+def test_default_conda_env_name():
+    assert default_conda_env_name("pubs", "MDOcean") == "mdocean-pubs"
+
+
+def test_check_env_auto_syncs_name_mismatch_before_conda_calls(
+    tmp_dir, monkeypatch
+):
+    with open("environment.yml", "w") as f:
+        calkit.ryaml.dump(
+            {
+                "name": "mdocean-pyxdsm-env",
+                "channels": ["conda-forge"],
+                "dependencies": ["python"],
+            },
+            f,
+        )
+    monkeypatch.setattr(calkit.conda, "find_conda_exe", lambda: None)
+    with pytest.raises(RuntimeError, match="Cannot find Conda executable"):
+        check_env(
+            env_fpath="environment.yml",
+            expected_name="mdocean-pubs",
+            verbose=False,
+        )
+    with open("environment.yml") as f:
+        synced = calkit.ryaml.load(f)
+    assert synced["name"] == "mdocean-pubs"
 
 
 def delete_env(name: str):

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1061,17 +1061,16 @@ Arguments:
 
 Options:
 
-| Option              | Type    | Required | Default         | Description                                                                                                                                                                                     |
-| ------------------- | ------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--name`, `-n`      | text    | yes      |                 | Environment name.                                                                                                                                                                               |
-| `--conda-name`      | text    | no       |                 | Name to use in the Conda environment file, if desired. Will be automatically generated if not provided. Note that these should be unique since Conda environments are a system-wide collection. |
-| `--path`            | text    | no       | environment.yml | Environment YAML file path.                                                                                                                                                                     |
-| `--pip`             | text    | no       |                 | Packages to install with pip.                                                                                                                                                                   |
-| `--prefix`          | text    | no       |                 | Prefix for environment location.                                                                                                                                                                |
-| `--description`     | text    | no       |                 | Description.                                                                                                                                                                                    |
-| `--overwrite`, `-f` | boolean | no       | False           | Overwrite any existing environment with this name.                                                                                                                                              |
-| `--no-commit`       | boolean | no       | False           | Do not commit changes.                                                                                                                                                                          |
-| `--no-check`        | boolean | no       | False           | Do not check environment is up-to-date after creation.                                                                                                                                          |
+| Option              | Type    | Required | Default         | Description                                            |
+| ------------------- | ------- | -------- | --------------- | ------------------------------------------------------ |
+| `--name`, `-n`      | text    | yes      |                 | Environment name.                                      |
+| `--path`            | text    | no       | environment.yml | Environment YAML file path.                            |
+| `--pip`             | text    | no       |                 | Packages to install with pip.                          |
+| `--prefix`          | text    | no       |                 | Prefix for environment location.                       |
+| `--description`     | text    | no       |                 | Description.                                           |
+| `--overwrite`, `-f` | boolean | no       | False           | Overwrite any existing environment with this name.     |
+| `--no-commit`       | boolean | no       | False           | Do not commit changes.                                 |
+| `--no-check`        | boolean | no       | False           | Do not check environment is up-to-date after creation. |
 
 <a id="subcommand-new-uv-env"></a>
 
@@ -2311,14 +2310,16 @@ calkit check conda-env [OPTIONS]
 
 Options:
 
-| Option           | Type    | Required | Default         | Description                                                                                                                                                   |
-| ---------------- | ------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--file`, `-f`   | text    | no       | environment.yml | Path to conda environment YAML file.                                                                                                                          |
-| `--output`, `-o` | text    | no       |                 | Path to which existing environment should be exported. If not specified, will have the same filename with '-lock' appended to it, keeping the same extension. |
-| `--input`        | text    | no       |                 | Alternative lock file input paths.                                                                                                                            |
-| `--input-delete` | text    | no       |                 | Alternative lock file input paths to delete after use.                                                                                                        |
-| `--relaxed`      | boolean | no       | False           | Treat conda and pip dependencies as equivalent.                                                                                                               |
-| `--quiet`, `-q`  | boolean | no       | False           | Be quiet.                                                                                                                                                     |
+| Option                                    | Type    | Required | Default         | Description                                                                                                                                                   |
+| ----------------------------------------- | ------- | -------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--file`, `-f`                            | text    | no       | environment.yml | Path to conda environment YAML file.                                                                                                                          |
+| `--output`, `-o`                          | text    | no       |                 | Path to which existing environment should be exported. If not specified, will have the same filename with '-lock' appended to it, keeping the same extension. |
+| `--input`                                 | text    | no       |                 | Alternative lock file input paths.                                                                                                                            |
+| `--input-delete`                          | text    | no       |                 | Alternative lock file input paths to delete after use.                                                                                                        |
+| `--relaxed`                               | boolean | no       | False           | Treat conda and pip dependencies as equivalent.                                                                                                               |
+| `--quiet`, `-q`                           | boolean | no       | False           | Be quiet.                                                                                                                                                     |
+| `--auto-sync-name`, `--no-auto-sync-name` | boolean | no       | True            | Automatically update the 'name' in the conda spec file to the expected canonical name when they differ.                                                       |
+| `--expected-name`                         | text    | no       |                 |                                                                                                                                                               |
 
 <a id="subcommand-check-venv"></a>
 


### PR DESCRIPTION
Resolves #794 

## TODO

- [ ] Write out clearly how we expect this to work. Are the names allowed to go out of sync, or do we require the Calkit name convention to be followed for Conda environments?