### PR TITLE
Rationalize slurm env setup command usage and detect interpreter for script inputs

### DIFF
--- a/calkit/cli/slurm.py
+++ b/calkit/cli/slurm.py
@@ -87,7 +87,8 @@ def run_sbatch(
             "--setup",
             help=(
                 "Shell setup command to run before launching the target "
-                "(repeat for multiple commands)."
+                "(repeat for multiple commands). Will ignore environment's "
+                "default setup commands."
             ),
         ),
     ] = [],

--- a/calkit/cli/slurm.py
+++ b/calkit/cli/slurm.py
@@ -174,7 +174,26 @@ def run_sbatch(
     if setup_cmds:
         # Run setup and target in the same shell so setup side effects (like
         # module loads) persist for the target command.
-        wrapped_target = shlex.join([target] + args)
+        wrapped_target_parts = [target] + args
+        if not is_command and os.path.isfile(target):
+            # `sbatch <script>` can run a non-executable script file, but
+            # `--wrap '<script>'` requires execute permission. For wrapped
+            # execution, invoke through the script interpreter when needed.
+            if not os.access(target, os.X_OK):
+                interpreter = None
+                try:
+                    with open(target, "r", encoding="utf-8") as f:
+                        first_line = f.readline().strip()
+                    if first_line.startswith("#!"):
+                        shebang = first_line[2:].strip()
+                        if shebang:
+                            interpreter = shlex.split(shebang)
+                except OSError:
+                    interpreter = None
+                if interpreter is None:
+                    interpreter = ["bash"]
+                wrapped_target_parts = interpreter + [target] + args
+        wrapped_target = shlex.join(wrapped_target_parts)
         setup_chain = " && ".join([*setup_cmds, wrapped_target])
         cmd += ["--wrap", setup_chain]
         if not is_command and target not in deps:

--- a/calkit/cli/slurm.py
+++ b/calkit/cli/slurm.py
@@ -167,10 +167,9 @@ def run_sbatch(
                     f"but this is '{current_host}'"
                 )
         env_setup_cmds = env.get("default_setup", [])
-        if env_setup_cmds:
-            setup_cmds = [
-                s for s in [*env_setup_cmds, *setup_cmds] if s.strip()
-            ]
+        # Use environment default setup commands if user didn't provide any
+        if env_setup_cmds and not setup_cmds:
+            setup_cmds = [s for s in env_setup_cmds if s.strip()]
     if setup_cmds:
         # Run setup and target in the same shell so setup side effects (like
         # module loads) persist for the target command.

--- a/calkit/cli/slurm.py
+++ b/calkit/cli/slurm.py
@@ -163,8 +163,8 @@ def run_sbatch(
                 and current_fqdn != env_host
             ):
                 raise_error(
-                    f"Environment '{environment}' is for host '{env_host}', but "
-                    f"this is '{current_host}'"
+                    f"Environment '{environment}' is for host '{env_host}', "
+                    f"but this is '{current_host}'"
                 )
         env_setup_cmds = env.get("default_setup", [])
         if env_setup_cmds:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2693,16 +2693,16 @@ Arguments:
 
 Options:
 
-| Option                  | Type    | Required | Default | Description                                                                                                        |
-| ----------------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------ |
-| `--name`, `-n`          | text    | yes      |         | Job name.                                                                                                          |
-| `--environment`, `-e`   | text    | yes      |         | Calkit (slurm) environment to use for the job.                                                                     |
-| `--dep`, `-d`           | text    | no       |         | Additional dependencies to track, which if changed signify a job is invalid.                                       |
-| `--out`, `-o`           | text    | no       |         | Non-persistent output files or directories produced by the job, which will be deleted before submitting a new job. |
-| `--sbatch-option`, `-s` | text    | no       |         | Additional options to pass to sbatch (no spaces allowed).                                                          |
-| `--setup`               | text    | no       |         | Shell setup command to run before launching the target (repeat for multiple commands).                             |
-| `--log-path`            | text    | no       |         | Output log path.                                                                                                   |
-| `--command`             | boolean | no       |         | Whether the target is a command instead of a script.                                                               |
+| Option                  | Type    | Required | Default | Description                                                                                                                              |
+| ----------------------- | ------- | -------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `--name`, `-n`          | text    | yes      |         | Job name.                                                                                                                                |
+| `--environment`, `-e`   | text    | yes      |         | Calkit (slurm) environment to use for the job.                                                                                           |
+| `--dep`, `-d`           | text    | no       |         | Additional dependencies to track, which if changed signify a job is invalid.                                                             |
+| `--out`, `-o`           | text    | no       |         | Non-persistent output files or directories produced by the job, which will be deleted before submitting a new job.                       |
+| `--sbatch-option`, `-s` | text    | no       |         | Additional options to pass to sbatch (no spaces allowed).                                                                                |
+| `--setup`               | text    | no       |         | Shell setup command to run before launching the target (repeat for multiple commands). Will ignore environment's default setup commands. |
+| `--log-path`            | text    | no       |         | Output log path.                                                                                                                         |
+| `--command`             | boolean | no       |         | Whether the target is a command instead of a script.                                                                                     |
 
 <a id="subcommand-slurm-queue"></a>
 


### PR DESCRIPTION
## TODO

- [ ] Make sure this is covered in a test
- [ ] Make consistent with options handling, i.e., do we merge or ignore defaults if any options are set in a stage? We currently have a "use" flag, but it should be named something like "merge". This should probably happen in the `calkit slurm batch` function, not the stage command. This way we don't need environment information to mutate the stage. However, we then need to export a slurm env lock as a DVC dep so we invalidate a stage when the default options change if they are being used. This might then invalidate stages that don't use any defaults.