### PR TITLE
Use calkit for all ck remote names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ calk9
 dist
 *.vsix
 vscode-ext/out
+.claude

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -120,7 +120,7 @@ def setup_remote_auth():
         remotes = get_remotes()
     except Exception:
         raise_error("Cannot list DVC remotes; check DVC config for errors")
-    ck_remote_name = calkit.config.get_app_name()
+    ck_remote_name = calkit.dvc.make_remote_name()
     for name, url in remotes.items():
         if name == ck_remote_name or name.startswith(f"{ck_remote_name}:"):
             typer.echo(f"Setting up authentication for DVC remote: {name}")

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -70,11 +70,14 @@ def unset_config_value(key: str):
 @config_app.command(name="setup-remote", help="Alias for 'remote'.")
 @config_app.command(name="remote")
 def setup_remote(
-    ck: Annotated[
+    http: Annotated[
         bool,
         typer.Option(
-            "--ck",
-            help="Use a ck:// URL for the 'calkit' DVC remote.",
+            "--http",
+            help=(
+                "Use the legacy HTTP URL for the Calkit DVC remote instead "
+                "of ck://."
+            ),
         ),
     ] = False,
     no_commit: Annotated[
@@ -88,7 +91,7 @@ def setup_remote(
     the local config.
     """
     try:
-        configure_remote(use_ck=ck)
+        configure_remote(use_ck=not http)
         set_remote_auth()
     except subprocess.CalledProcessError:
         if not os.path.isfile(".dvc/config"):
@@ -120,9 +123,8 @@ def setup_remote_auth():
         remotes = get_remotes()
     except Exception:
         raise_error("Cannot list DVC remotes; check DVC config for errors")
-    ck_remote_name = calkit.dvc.make_remote_name()
     for name, url in remotes.items():
-        if name == ck_remote_name or name.startswith(f"{ck_remote_name}:"):
+        if calkit.dvc.detect_calkit_remote_type(name, url) is not None:
             typer.echo(f"Setting up authentication for DVC remote: {name}")
             set_remote_auth(remote_name=name)
 

--- a/calkit/cli/config.py
+++ b/calkit/cli/config.py
@@ -91,8 +91,8 @@ def setup_remote(
     the local config.
     """
     try:
-        configure_remote(use_ck=not http)
-        set_remote_auth()
+        remote_name = configure_remote(use_ck=not http)
+        set_remote_auth(remote_name=remote_name)
     except subprocess.CalledProcessError:
         if not os.path.isfile(".dvc/config"):
             raise_error(

--- a/calkit/cli/import_.py
+++ b/calkit/cli/import_.py
@@ -63,6 +63,16 @@ def import_dataset(
             help="Force adding the dataset even if it already exists.",
         ),
     ] = False,
+    http: Annotated[
+        bool,
+        typer.Option(
+            "--http",
+            help=(
+                "Use the legacy HTTP URL for the imported project's DVC "
+                "remote instead of ck://."
+            ),
+        ),
+    ] = not calkit.dvc.USE_CK_REMOTE_BY_DEFAULT,
 ):
     """Import a dataset.
 
@@ -111,7 +121,9 @@ def import_dataset(
         # have a token set for that remote
         typer.echo("Adding new DVC remote")
         remote = calkit.dvc.add_external_remote(
-            owner_name=owner_name, project_name=project_name
+            owner_name=owner_name,
+            project_name=project_name,
+            use_ck=not http,
         )
         repo.git.add(".dvc/config")
         # Import this data with DVC

--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -928,7 +928,7 @@ def pull(
     if not no_check_auth:
         # Check that our dvc remotes all have our DVC token set for them
         remotes = calkit.dvc.get_remotes()
-        ck_remote_name = calkit.config.get_app_name()
+        ck_remote_name = calkit.dvc.make_remote_name()
         for name, url in remotes.items():
             if (
                 name == ck_remote_name or name.startswith(f"{ck_remote_name}:")
@@ -963,7 +963,7 @@ def push(
         remotes = calkit.dvc.get_remotes()
         if not no_check_auth:
             # Check that our dvc remotes all have our DVC token set for them
-            ck_remote_name = calkit.config.get_app_name()
+            ck_remote_name = calkit.dvc.make_remote_name()
             for name, url in remotes.items():
                 if (
                     name == ck_remote_name

--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -928,11 +928,8 @@ def pull(
     if not no_check_auth:
         # Check that our dvc remotes all have our DVC token set for them
         remotes = calkit.dvc.get_remotes()
-        ck_remote_name = calkit.dvc.make_remote_name()
         for name, url in remotes.items():
-            if (
-                name == ck_remote_name or name.startswith(f"{ck_remote_name}:")
-            ) and url.startswith("http"):
+            if calkit.dvc.detect_calkit_remote_type(name, url) == "http":
                 typer.echo(f"Checking authentication for DVC remote: {name}")
                 calkit.dvc.set_remote_auth(remote_name=name)
     result = run_dvc_command(["pull"] + dvc_args)
@@ -963,12 +960,8 @@ def push(
         remotes = calkit.dvc.get_remotes()
         if not no_check_auth:
             # Check that our dvc remotes all have our DVC token set for them
-            ck_remote_name = calkit.dvc.make_remote_name()
             for name, url in remotes.items():
-                if (
-                    name == ck_remote_name
-                    or name.startswith(f"{ck_remote_name}:")
-                ) and url.startswith("http"):
+                if calkit.dvc.detect_calkit_remote_type(name, url) == "http":
                     typer.echo(
                         f"Checking authentication for DVC remote: {name}"
                     )

--- a/calkit/dvc/core.py
+++ b/calkit/dvc/core.py
@@ -282,7 +282,9 @@ def configure_remote(wdir: str | None = None, use_ck: bool = False) -> str:
     else:
         base_url = calkit.cloud.get_base_url()
         remote_url = f"{base_url}/projects/{project_name}/dvc"
-    remote_name = get_app_name()
+    # ck remotes don't need different URLs for different endpoints, since we
+    # select with an environment variable
+    remote_name = get_app_name() if not use_ck else "calkit"
     result = run_dvc_command(
         ["remote", "add", "-d", "-f", remote_name, remote_url],
         cwd=wdir,

--- a/calkit/dvc/core.py
+++ b/calkit/dvc/core.py
@@ -24,6 +24,8 @@ from calkit.config import get_app_name
 logger = logging.getLogger(__package__)
 logger.setLevel(logging.INFO)
 
+USE_CK_REMOTE_BY_DEFAULT = False
+
 
 class CalkitDVCFileSystem(ObjectFileSystem):
     """DVC-facing filesystem wrapper for the ``ck://`` scheme."""
@@ -252,7 +254,14 @@ def run_dvc_command(argv: list[str], cwd: str | None = None) -> int:
     return run_dvc_cli(argv)
 
 
-def configure_remote(wdir: str | None = None, use_ck: bool = False) -> str:
+def make_remote_name(use_ck: bool = USE_CK_REMOTE_BY_DEFAULT) -> str:
+    """Generate a DVC remote name based on the app name or a default."""
+    return get_app_name() if not use_ck else "calkit"
+
+
+def configure_remote(
+    wdir: str | None = None, use_ck: bool = USE_CK_REMOTE_BY_DEFAULT
+) -> str:
     """Configure a DVC remote for the current project.
 
     TODO: Use the ck:// scheme by default once it's deemed stable.
@@ -284,7 +293,7 @@ def configure_remote(wdir: str | None = None, use_ck: bool = False) -> str:
         remote_url = f"{base_url}/projects/{project_name}/dvc"
     # ck remotes don't need different URLs for different endpoints, since we
     # select with an environment variable
-    remote_name = get_app_name() if not use_ck else "calkit"
+    remote_name = make_remote_name(use_ck=use_ck)
     result = run_dvc_command(
         ["remote", "add", "-d", "-f", remote_name, remote_url],
         cwd=wdir,
@@ -311,7 +320,7 @@ def clear_remote_local_http_auth(
     This clears values written to ``.dvc/config.local`` by HTTP auth setup.
     """
     if remote_name is None:
-        remote_name = get_app_name()
+        remote_name = make_remote_name()
     config_local = Path(wdir or ".") / ".dvc" / "config.local"
     if not config_local.is_file():
         return
@@ -344,7 +353,7 @@ def set_remote_auth(
     HTTP auth configuration.
     """
     if remote_name is None:
-        remote_name = get_app_name()
+        remote_name = make_remote_name()
     # Check if this is a ck:// remote (doesn't need HTTP auth)
     remotes = get_remotes(wdir=wdir)
     remote_url = remotes.get(remote_name, "")
@@ -393,7 +402,7 @@ def set_remote_auth(
 def add_external_remote(owner_name: str, project_name: str) -> dict:
     base_url = calkit.cloud.get_base_url()
     remote_url = f"{base_url}/projects/{owner_name}/{project_name}/dvc"
-    remote_name = f"{get_app_name()}:{owner_name}/{project_name}"
+    remote_name = f"{make_remote_name()}:{owner_name}/{project_name}"
     run_dvc_command(["remote", "add", "-f", remote_name, remote_url])
     run_dvc_command(["remote", "modify", remote_name, "auth", "custom"])
     set_remote_auth(remote_name)

--- a/calkit/dvc/core.py
+++ b/calkit/dvc/core.py
@@ -307,15 +307,13 @@ def configure_remote(
         if not url.endswith(".git"):
             url += ".git"
         repo.git.remote(["add", "origin", url])
+    remote_name = make_remote_name(use_ck=use_ck)
     if use_ck:
-        clear_remote_local_http_auth(wdir=wdir)
+        clear_remote_local_http_auth(remote_name=remote_name, wdir=wdir)
         remote_url = f"ck://{project_name}"
     else:
         base_url = calkit.cloud.get_base_url()
         remote_url = f"{base_url}/projects/{project_name}/dvc"
-    # ck remotes don't need different URLs for different endpoints, since we
-    # select with an environment variable
-    remote_name = make_remote_name(use_ck=use_ck)
     result = run_dvc_command(
         ["remote", "add", "-d", "-f", remote_name, remote_url],
         cwd=wdir,

--- a/calkit/dvc/core.py
+++ b/calkit/dvc/core.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import dvc.repo
 import git
@@ -24,7 +24,7 @@ from calkit.config import get_app_name
 logger = logging.getLogger(__package__)
 logger.setLevel(logging.INFO)
 
-USE_CK_REMOTE_BY_DEFAULT = False
+USE_CK_REMOTE_BY_DEFAULT = True
 
 
 class CalkitDVCFileSystem(ObjectFileSystem):
@@ -259,13 +259,35 @@ def make_remote_name(use_ck: bool = USE_CK_REMOTE_BY_DEFAULT) -> str:
     return get_app_name() if not use_ck else "calkit"
 
 
+def detect_calkit_remote_type(
+    name: str, url: str
+) -> Literal["ck", "http"] | None:
+    """Detect whether a DVC remote is a Calkit remote, and its scheme.
+
+    Returns ``"ck"`` or ``"http"`` for recognized Calkit remotes (including
+    external project remotes named like ``"<base>:<owner>/<project>"``), or
+    ``None`` if the remote isn't a Calkit remote we recognize.
+    """
+    candidates = {
+        make_remote_name(use_ck=False),
+        make_remote_name(use_ck=True),
+    }
+    name_matches = any(
+        name == c or name.startswith(f"{c}:") for c in candidates
+    )
+    if not name_matches:
+        return None
+    if url.startswith("ck://"):
+        return "ck"
+    if url.startswith("http"):
+        return "http"
+    return None
+
+
 def configure_remote(
     wdir: str | None = None, use_ck: bool = USE_CK_REMOTE_BY_DEFAULT
 ) -> str:
-    """Configure a DVC remote for the current project.
-
-    TODO: Use the ck:// scheme by default once it's deemed stable.
-    """
+    """Configure a DVC remote for the current project."""
     try:
         project_name = calkit.detect_project_name(wdir=wdir)
     except ValueError as e:
@@ -399,13 +421,23 @@ def set_remote_auth(
         )
 
 
-def add_external_remote(owner_name: str, project_name: str) -> dict:
-    base_url = calkit.cloud.get_base_url()
-    remote_url = f"{base_url}/projects/{owner_name}/{project_name}/dvc"
-    remote_name = f"{make_remote_name()}:{owner_name}/{project_name}"
+def add_external_remote(
+    owner_name: str,
+    project_name: str,
+    use_ck: bool = USE_CK_REMOTE_BY_DEFAULT,
+) -> dict:
+    if use_ck:
+        remote_url = f"ck://{owner_name}/{project_name}"
+    else:
+        base_url = calkit.cloud.get_base_url()
+        remote_url = f"{base_url}/projects/{owner_name}/{project_name}/dvc"
+    remote_name = (
+        f"{make_remote_name(use_ck=use_ck)}:{owner_name}/{project_name}"
+    )
     run_dvc_command(["remote", "add", "-f", remote_name, remote_url])
-    run_dvc_command(["remote", "modify", remote_name, "auth", "custom"])
-    set_remote_auth(remote_name)
+    if not use_ck:
+        run_dvc_command(["remote", "modify", remote_name, "auth", "custom"])
+        set_remote_auth(remote_name)
     return {"name": remote_name, "url": remote_url}
 
 

--- a/calkit/tests/dvc/test_core.py
+++ b/calkit/tests/dvc/test_core.py
@@ -93,6 +93,44 @@ def test_list_files_paths(tmp_dir):
     assert "file1.txt" in calkit.dvc.list_paths()
 
 
+def test_detect_calkit_remote_type():
+    http_name = calkit.dvc.make_remote_name(use_ck=False)
+    ck_name = calkit.dvc.make_remote_name(use_ck=True)
+    # Default-named HTTP remote
+    assert (
+        calkit.dvc.detect_calkit_remote_type(http_name, "https://example.com")
+        == "http"
+    )
+    # Default-named ck remote
+    assert (
+        calkit.dvc.detect_calkit_remote_type(ck_name, "ck://owner/proj")
+        == "ck"
+    )
+    # External-project remote with ":" suffix
+    assert (
+        calkit.dvc.detect_calkit_remote_type(
+            f"{http_name}:owner/proj", "https://example.com/o/p/dvc"
+        )
+        == "http"
+    )
+    assert (
+        calkit.dvc.detect_calkit_remote_type(
+            f"{ck_name}:owner/proj", "ck://owner/proj"
+        )
+        == "ck"
+    )
+    # Unrelated remote name
+    assert (
+        calkit.dvc.detect_calkit_remote_type("something", "https://sup.com")
+        is None
+    )
+    # Matching name but unknown URL scheme
+    assert (
+        calkit.dvc.detect_calkit_remote_type(http_name, "ssh://git@host/repo")
+        is None
+    )
+
+
 def test_configure_remote_ck_uses_ck_scheme_and_skips_http_auth(monkeypatch):
     monkeypatch.setattr(calkit, "detect_project_name", lambda wdir=None: "o/p")
 
@@ -131,6 +169,55 @@ def test_configure_remote_ck_uses_ck_scheme_and_skips_http_auth(monkeypatch):
             None,
         )
     ]
+
+
+def test_add_external_remote(monkeypatch):
+    calls = []
+    auth_calls = []
+    monkeypatch.setattr(
+        calkit.dvc.core,
+        "run_dvc_command",
+        lambda argv, cwd=None: calls.append((argv, cwd)) or 0,
+    )
+    monkeypatch.setattr(
+        calkit.dvc.core,
+        "set_remote_auth",
+        lambda name: auth_calls.append(name),
+    )
+    # HTTP case: builds URL from cloud base, sets custom auth
+    monkeypatch.setattr(
+        calkit.cloud, "get_base_url", lambda: "https://example.com"
+    )
+    out = calkit.dvc.add_external_remote("o", "p", use_ck=False)
+    http_name = f"{calkit.dvc.make_remote_name(use_ck=False)}:o/p"
+    assert out == {
+        "name": http_name,
+        "url": "https://example.com/projects/o/p/dvc",
+    }
+    assert calls == [
+        (
+            [
+                "remote",
+                "add",
+                "-f",
+                http_name,
+                "https://example.com/projects/o/p/dvc",
+            ],
+            None,
+        ),
+        (["remote", "modify", http_name, "auth", "custom"], None),
+    ]
+    assert auth_calls == [http_name]
+    # ck case: builds ck:// URL, skips HTTP auth modify and set_remote_auth
+    calls.clear()
+    auth_calls.clear()
+    out = calkit.dvc.add_external_remote("o", "p", use_ck=True)
+    ck_name = f"{calkit.dvc.make_remote_name(use_ck=True)}:o/p"
+    assert out == {"name": ck_name, "url": "ck://o/p"}
+    assert calls == [
+        (["remote", "add", "-f", ck_name, "ck://o/p"], None),
+    ]
+    assert auth_calls == []
 
 
 def test_set_remote_auth_ck_remote_clears_local_http_auth(

--- a/calkit/tests/dvc/test_core.py
+++ b/calkit/tests/dvc/test_core.py
@@ -116,7 +116,7 @@ def test_configure_remote_ck_uses_ck_scheme_and_skips_http_auth(monkeypatch):
         lambda remote_name=None, wdir=None: events.append("clear"),
     )
     out = calkit.dvc.configure_remote(use_ck=True)
-    assert out == calkit.config.get_app_name()
+    assert out == calkit.dvc.make_remote_name(use_ck=True)
     assert events and events[0] == "clear"
     assert calls == [
         (
@@ -125,7 +125,7 @@ def test_configure_remote_ck_uses_ck_scheme_and_skips_http_auth(monkeypatch):
                 "add",
                 "-d",
                 "-f",
-                calkit.config.get_app_name(),
+                calkit.dvc.make_remote_name(use_ck=True),
                 "ck://o/p",
             ],
             None,
@@ -136,7 +136,7 @@ def test_configure_remote_ck_uses_ck_scheme_and_skips_http_auth(monkeypatch):
 def test_set_remote_auth_ck_remote_clears_local_http_auth(
     monkeypatch, tmp_path
 ):
-    remote_name = calkit.config.get_app_name()
+    remote_name = calkit.dvc.make_remote_name()
     monkeypatch.setattr(
         calkit.dvc.core,
         "get_remotes",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -707,10 +707,10 @@ calkit config remote [OPTIONS]
 
 Options:
 
-| Option        | Type    | Required | Default | Description                                  |
-| ------------- | ------- | -------- | ------- | -------------------------------------------- |
-| `--ck`        | boolean | no       | False   | Use a ck:// URL for the 'calkit' DVC remote. |
-| `--no-commit` | boolean | no       | False   | Do not commit changes to DVC config.         |
+| Option        | Type    | Required | Default | Description                                                         |
+| ------------- | ------- | -------- | ------- | ------------------------------------------------------------------- |
+| `--http`      | boolean | no       | False   | Use the legacy HTTP URL for the Calkit DVC remote instead of ck://. |
+| `--no-commit` | boolean | no       | False   | Do not commit changes to DVC config.                                |
 
 <a id="subcommand-config-remote-auth"></a>
 
@@ -1808,12 +1808,13 @@ Arguments:
 
 Options:
 
-| Option              | Type    | Required | Default | Description                                         |
-| ------------------- | ------- | -------- | ------- | --------------------------------------------------- |
-| `--filter-paths`    | text    | no       |         | Filter paths in target dataset if it's a folder.    |
-| `--no-commit`       | boolean | no       | False   | Do not commit changes to repo.                      |
-| `--no-dvc-pull`     | boolean | no       | False   | Do not pull imported dataset with DVC.              |
-| `--overwrite`, `-f` | boolean | no       | False   | Force adding the dataset even if it already exists. |
+| Option              | Type    | Required | Default | Description                                                                     |
+| ------------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------- |
+| `--filter-paths`    | text    | no       |         | Filter paths in target dataset if it's a folder.                                |
+| `--no-commit`       | boolean | no       | False   | Do not commit changes to repo.                                                  |
+| `--no-dvc-pull`     | boolean | no       | False   | Do not pull imported dataset with DVC.                                          |
+| `--overwrite`, `-f` | boolean | no       | False   | Force adding the dataset even if it already exists.                             |
+| `--http`            | boolean | no       | False   | Use the legacy HTTP URL for the imported project's DVC remote instead of ck://. |
 
 <a id="subcommand-import-environment"></a>
 


### PR DESCRIPTION
Only really matters for dev or staging interaction, but good to include.

## TODO

- [x] Ensure this is covered by a test--maybe move into a `dvc.make_remote_name(use_ck...)` function to test more easily and make it possible to create the remote name elsewhere.
- [x] Rationalize how we detect what remotes are Calkit remotes, and what type they are, `ck` or `http`, and how we determine if we need to configure their auth, etc.
- [x] Ensure we will use a `ck` remote for a dataset import.
- [x] Make `ck` remotes default.
- [ ] This should really be in `calkit update dvc-remote` or something. `config` is more for the system or for configuring Calkit itself.