### PR TITLE
Add `ck` executable alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ all scientific or analytical computing projects.
 
 <!-- INCLUDE: docs/quickstart.md +1 -->
 
+<!-- prettier-ignore -->
+!!! note
+    `ck` is an abbreviated alias for the `calkit` executable.
+    All `calkit` commands can be run as `ck` instead, e.g., `ck save -am "..."`.
+
 ### From an existing project
 
 If you want to use Calkit with an existing project,

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,5 +1,10 @@
 # CLI reference
 
+<!-- prettier-ignore -->
+!!! note
+    `ck` is an abbreviated alias for the `calkit` executable.
+    All `calkit` commands can be run as `ck` instead, e.g., `ck save -am "..."`.
+
 ## Top-level commands
 
 | Command                                       | Description                                                        |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,5 +1,10 @@
 # Quickstart
 
+<!-- prettier-ignore -->
+!!! note
+    `ck` is an abbreviated alias for the `calkit` executable.
+    All `calkit` commands can be run as `ck` instead, e.g., `ck save -am "..."`.
+
 ## From an existing project
 
 If you want to use Calkit with an existing project,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ ck = "calkit.fs:CalkitFileSystem"
 [project.scripts]
 calkit = "calkit.cli:run"
 calk9 = "calkit.cli:run"
+ck = "calkit.cli:run"
 
 [tool.hatch.build.targets.wheel]
 packages = ["calkit"]
@@ -155,6 +156,11 @@ ignore = ["W002"]
 [tool.hatch.version]
 source = "vcs"
 tag-pattern = "^v(?P<version>.+)$"
+
+[tool.hatch.version.raw-options]
+git_describe_command = [
+    "git", "describe", "--dirty", "--tags", "--long", "--match", "v[0-9]*",
+]
 
 [tool.mypy]
 files = ["calkit"]

--- a/scripts/generate-docs-references.py
+++ b/scripts/generate-docs-references.py
@@ -295,6 +295,15 @@ def generate_cli_markdown() -> str:
     lines: list[str] = []
     lines.append("# CLI reference")
     lines.append("")
+    lines.append("<!-- prettier-ignore -->")
+    lines.append("!!! note")
+    lines.append(
+        "    `ck` is an abbreviated alias for the `calkit` executable."
+    )
+    lines.append(
+        '    All `calkit` commands can be run as `ck` instead, e.g., `ck save -am "..."`.'
+    )
+    lines.append("")
     if top_summary:
         lines.append(top_summary)
         lines.append("")
@@ -642,7 +651,7 @@ def generate_stage_kinds_markdown() -> str:
                 _annotation_to_text(field.annotation),
                 "yes" if _is_required(field) else "no",
                 _default_to_text(field.default),
-            )
+            )  # type: ignore
         )
     lines.append(
         make_table(
@@ -678,7 +687,7 @@ def generate_stage_kinds_markdown() -> str:
                     _annotation_to_text(field.annotation),
                     "yes" if _is_required(field) else "no",
                     _default_to_text(field.default),
-                )
+                )  # type: ignore
             )
         if extra_rows:
             lines.append(


### PR DESCRIPTION
Resolves #744 

We don't give the user any control over this, but it looks like the Collective Knowledge CLI is now deprecated anyway.