### PR TITLE
Filter out warnings about frozen stages and use pixi install instead of lock

### DIFF
--- a/calkit/cli/check.py
+++ b/calkit/cli/check.py
@@ -381,7 +381,7 @@ def check_environment(
             quiet=not verbose,
         )
     elif env["kind"] == "pixi":
-        cmd = ["pixi", "lock"]
+        cmd = ["pixi", "install"]
         env_dir = os.path.dirname(env["path"])
         if env_dir:
             cmd += ["--manifest-path", env["path"]]

--- a/calkit/dvc/core.py
+++ b/calkit/dvc/core.py
@@ -26,6 +26,24 @@ logger.setLevel(logging.INFO)
 USE_CK_REMOTE_BY_DEFAULT = True
 
 
+class _FrozenStageWarningFilter(logging.Filter):
+    """Drop DVC's "stage is frozen" warnings.
+
+    DVC emits these for every frozen stage on every ``status``/``repro`` call
+    ("... not going to be shown in the status output." and "... not going to
+    be reproduced."). Frozen stages are pinned by design, so the warnings are
+    noise — the substring shared by both variants is matched here.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "is frozen. Its dependencies are" not in record.getMessage()
+
+
+_frozen_stage_warning_filter = _FrozenStageWarningFilter()
+for _name in ("dvc.repo.reproduce", "dvc.repo.status"):
+    logging.getLogger(_name).addFilter(_frozen_stage_warning_filter)
+
+
 class CalkitDVCFileSystem(ObjectFileSystem):
     """DVC-facing filesystem wrapper for the ``ck://`` scheme."""
 

--- a/calkit/pipeline.py
+++ b/calkit/pipeline.py
@@ -1,7 +1,6 @@
 """Pipeline-related functionality."""
 
 import itertools
-import logging
 import os
 from collections.abc import Callable
 from pathlib import Path
@@ -16,17 +15,6 @@ from calkit.models.pipeline import (
     PathOutput,
     Pipeline,
 )
-
-
-class _FrozenStageWarningFilter(logging.Filter):
-    """Drop only DVC's "stage is frozen" status warning.
-
-    Frozen stages are intentionally hidden from Calkit status output, so this
-    warning is noise; all other ``dvc.repo.status`` diagnostics pass through.
-    """
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        return "is frozen. Its dependencies are" not in record.getMessage()
 
 
 def _coerce_frozen(value: object) -> bool:
@@ -641,19 +629,9 @@ def get_status(
                 return PipelineStatus.model_validate(result)
         try:
             dvc_repo = calkit.dvc.get_dvc_repo()
-            # Frozen stages emit a "stage is frozen. Its dependencies are not
-            # going to be shown in the status output." warning from DVC's
-            # status module; suppress just that message since we intentionally
-            # hide frozen stages from the Calkit status output entirely.
-            # A targeted filter is used (rather than raising the logger level)
-            # so unrelated DVC diagnostics are still emitted.
-            dvc_status_logger = logging.getLogger("dvc.repo.status")
-            frozen_filter = _FrozenStageWarningFilter()
-            dvc_status_logger.addFilter(frozen_filter)
-            try:
-                raw_status = dvc_repo.status(targets=targets)
-            finally:
-                dvc_status_logger.removeFilter(frozen_filter)
+            # calkit.dvc.core installs a filter on dvc.repo.status that drops
+            # the noisy frozen-stage warning, so the call here stays quiet.
+            raw_status = dvc_repo.status(targets=targets)
         except Exception as e:
             result["errors"].append(
                 "Failed to get pipeline status from DVC: "
@@ -1296,7 +1274,7 @@ def get_matrix_item_targets(
 
     repo = calkit.dvc.get_dvc_repo(wdir)
     prefix = stage_name + "@"
-    items = [s for s in repo.index.stages if (s.name or "").startswith(prefix)]
+    items = [s for s in repo.index.stages if (s.name or "").startswith(prefix)]  # type: ignore
     item_set = set(items)
     upstreams: set = set()
     for item in items:

--- a/calkit/tests/dvc/test_core.py
+++ b/calkit/tests/dvc/test_core.py
@@ -55,6 +55,25 @@ def test_hash_directory():
     assert res["md5"] == "ca2ffab71e00d528b974e583d789ec97.dir"
 
 
+def test_frozen_stage_reproduce_warning_is_suppressed(caplog):
+    # Import side effect: loading calkit.dvc installs the filter on the
+    # dvc.repo.reproduce logger.
+    import logging
+
+    import calkit.dvc  # noqa: F401
+
+    logger = logging.getLogger("dvc.repo.reproduce")
+    with caplog.at_level(logging.WARNING, logger="dvc.repo.reproduce"):
+        logger.warning(
+            "%s is frozen. Its dependencies are not going to be reproduced.",
+            "stage: 'foo@1'",
+        )
+        logger.warning("some other warning that must pass through")
+    messages = [r.getMessage() for r in caplog.records]
+    assert not any("is frozen" in m for m in messages)
+    assert any("must pass through" in m for m in messages)
+
+
 def test_register_ck_scheme_updates_schema_and_registry():
     register_ck_scheme()
 


### PR DESCRIPTION
`pixi lock` ends up re-solving the environment, which is not what we want. `install` is the equivalent of `uv sync` or `ck check env`.