### PR TITLE
Handle unnamed DVC stages from tracked files

### DIFF
--- a/calkit/pipeline.py
+++ b/calkit/pipeline.py
@@ -1273,7 +1273,11 @@ def get_matrix_item_targets(
 
     repo = calkit.dvc.get_dvc_repo(wdir)
     prefix = stage_name + "@"
-    items = [s for s in repo.index.stages if (s.name or "").startswith(prefix)]  # type: ignore
+    items = [
+        s
+        for s in repo.index.stages
+        if (getattr(s, "name", None) or "").startswith(prefix)
+    ]
     item_set = set(items)
     upstreams: set = set()
     for item in items:

--- a/calkit/tests/test_pipeline.py
+++ b/calkit/tests/test_pipeline.py
@@ -2034,6 +2034,11 @@ def test_get_matrix_item_targets(tmp_dir):
     }
     with open("dvc.yaml", "w") as f:
         calkit.ryaml.dump(dvc_yaml, f)
+    # A single-file `.dvc` stage exposes a base `Stage` with no `name` attr;
+    # the matrix lookup must skip it instead of raising AttributeError.
+    with open("tracked.txt", "w") as f:
+        f.write("tracked\n")
+    subprocess.check_call([sys.executable, "-m", "dvc", "add", "tracked.txt"])
     items, upstreams = calkit.pipeline.get_matrix_item_targets("work")
     # Each iteration is addressable; the shared upstream is reported so the
     # caller can build it before fanning the items out concurrently. Results


### PR DESCRIPTION
Was causing failures running concurrent stages in scheduler environments.