### PR TITLE
Enable executing notebooks in docker environments

### DIFF
--- a/calkit/cli/notebooks.py
+++ b/calkit/cli/notebooks.py
@@ -490,7 +490,17 @@ def execute_notebook(
         typer.echo(f"Using {language} as notebook language")
     # First, ensure the specified environment has a kernel we can use
     # We need to check the environment type and create the kernel if needed
-    if language.lower() in ["python", "julia", "r"]:
+    docker_env = env.get("kind") == "docker"
+    if docker_env:
+        # Docker environments run the kernel inside the container, so there is
+        # no host kernel to register. Use the container's own kernel (default
+        # 'python3', overridable with the env's 'jupyter_kernel' key) and
+        # execute with Papermill inside the container further below.
+        kernel_name = env.get("jupyter_kernel") or {"r": "ir"}.get(
+            language.lower(), "python3"
+        )
+        display_name = kernel_name
+    elif language.lower() in ["python", "julia", "r"]:
         kernel_name, display_name = check_env_kernel(
             env_name=env_name,
             no_check=no_check,
@@ -563,10 +573,70 @@ def execute_notebook(
         typer.echo(f"Using kernel: {kernel_name}")
         typer.echo(f"Running with cwd: {notebook_dir}")
         typer.echo(f"Output will be saved to: {fpath_out_exec}")
-    # If this is a Python, Julia, or R notebook, we can use Papermill
+    # If this is a Python, Julia, or R notebook, we can use Papermill.
     # If it's a MATLAB notebook, we need to use the MATLAB kernel inside the
-    # specified environment
-    if language.lower() in ["python", "julia", "r"]:
+    # specified environment.
+    # Exception: If the environment is a Docker environment, we run Papermill
+    # inside the container so the kernel (which lives in the image) and
+    # Papermill share a process namespace---this avoids registering a host
+    # kernel and cross-container networking entirely
+    if docker_env:
+        # run_in_env mounts the project at the working directory and applies
+        # the env's user/platform/args, so we only need to invoke Papermill
+        # ipykernel is in the image, but Papermill may not be, so install it
+        # on demand (warning the user) before executing. We install into a
+        # writable temp dir on PYTHONPATH rather than the image's site-packages:
+        # run_in_env maps the host user into the container, so writing to the
+        # system location is typically denied, but /tmp is world-writable
+        pm_target = "/tmp/calkit-papermill"
+        pythonpath = f"PYTHONPATH={pm_target}"
+        pm_cmd = [
+            pythonpath,
+            "python",
+            "-c",
+            "import papermill",
+            "2>/dev/null",
+            "||",
+            "(",
+            "echo",
+            "papermill not found in image; installing it with pip...",
+            "&&",
+            "python",
+            "-m",
+            "pip",
+            "install",
+            "-q",
+            "--target",
+            pm_target,
+            "papermill",
+            ")",
+            "&&",
+            pythonpath,
+            "python",
+            "-m",
+            "papermill",
+            path,
+            fpath_out_exec,
+            "-k",
+            kernel_name,
+            "--log-output",
+        ]
+        if notebook_dir:
+            pm_cmd += ["--cwd", notebook_dir]
+        if parsed_params:
+            # JSON is valid YAML, so pass parameters as base64-encoded JSON to
+            # avoid shell-quoting issues across the container boundary
+            params_b64 = base64.b64encode(
+                json.dumps(parsed_params).encode()
+            ).decode()
+            pm_cmd += ["-b", params_b64]
+        run_in_env(
+            pm_cmd,
+            env_name=env_name,
+            no_check=no_check,
+            verbose=verbose,
+        )
+    elif language.lower() in ["python", "julia", "r"]:
         papermill.execute_notebook(
             input_path=path,
             output_path=fpath_out_exec,

--- a/calkit/models/core.py
+++ b/calkit/models/core.py
@@ -96,8 +96,6 @@ class Environment(BaseModel):
     # without a spec file (e.g. Matlab/Slurm/PBS) don't carry an unused field
     # and a required ``path`` doesn't conflict with the base's optional one.
     description: str | None = None
-    stage: str | None = None
-    default: bool | None = None
 
 
 class CondaEnvironment(Environment):
@@ -112,6 +110,8 @@ class VenvEnvironment(Environment):
     # If unset, the prefix is resolved on the fly (defaults to .venv next to
     # the spec file, nesting under .calkit/envs/{name}/.venv on conflict)
     prefix: str | None = None
+    # Python version to use when creating the environment
+    python: str | None = None
 
 
 class UvEnvironment(Environment):
@@ -125,6 +125,8 @@ class UvVenvEnvironment(Environment):
     # If unset, the prefix is resolved on the fly (defaults to .venv next to
     # the spec file, nesting under .calkit/envs/{name}/.venv on conflict)
     prefix: str | None = None
+    # Python version to use when creating the environment
+    python: str | None = None
 
 
 class PixiEnvironment(Environment):
@@ -153,6 +155,24 @@ class DockerEnvironment(Environment):
     shell: Literal["bash", "sh"] = "sh"
     command_mode: Literal["shell", "entrypoint"] = "shell"
     platform: str | None = None
+    # Working directory inside the container; defaults to ``/work`` at run time
+    wdir: str | None = None
+    # User to run the container as; defaults to the host user at run time
+    user: str | None = None
+    # Files added to the container as dependencies
+    deps: list[str] | None = None
+    # Environment variables to set in the container
+    env_vars: dict[str, str] | None = None
+    # Ports to expose, e.g. ``"8080:80"``
+    ports: list[str] | None = None
+    # GPUs to make available, passed to ``docker run --gpus``
+    gpus: str | None = None
+    # Extra arguments passed to ``docker run``
+    args: list[str] | None = None
+    # Name of the Jupyter kernel inside the image, used when executing
+    # notebooks with ``calkit nb execute``; defaults to ``python3`` (or ``ir``
+    # for R images)
+    jupyter_kernel: str | None = None
 
 
 class REnvironment(Environment):
@@ -195,6 +215,7 @@ class SSHEnvironment(BaseModel):
     key: str | None = None
     send_paths: list[str] = ["./*"]
     get_paths: list[str] = ["*"]
+    description: str | None = None
 
 
 class Software(BaseModel):

--- a/calkit/tests/cli/test_notebooks.py
+++ b/calkit/tests/cli/test_notebooks.py
@@ -10,6 +10,7 @@ import sys
 import pytest
 
 import calkit
+import calkit.notebooks
 
 
 def test_clean_notebook_outputs(tmp_dir):
@@ -264,3 +265,87 @@ def test_execute_notebook_auto_env(tmp_dir):
     # TODO: Check if the notebook is saved in the project and if it
     # has an environment specified, either in the notebooks section or a
     # pipeline stage
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Docker Linux images are unavailable on windows-latest GHA runners",
+)
+def test_execute_notebook_docker(tmp_dir):
+    # A Docker environment runs the kernel inside the container, so we execute
+    # with Papermill inside the container rather than registering a host kernel
+    if shutil.which("docker") is None:
+        pytest.skip("Docker is not available")
+    image = "calkit-nb-docker-test:latest"
+    # Bake ipykernel and Papermill into the image so execution is deterministic
+    with open("Dockerfile", "w") as f:
+        f.write(
+            "FROM python:3.10-slim\n"
+            "RUN pip install --no-cache-dir ipykernel papermill\n"
+            "WORKDIR /work\n"
+        )
+    subprocess.check_call(["docker", "build", "-t", image, "."])
+    subprocess.check_call(["calkit", "init"])
+    ck_info = {
+        "environments": {
+            "docker-env": {"kind": "docker", "image": image, "wdir": "/work"}
+        }
+    }
+    with open("calkit.yaml", "w") as f:
+        calkit.ryaml.dump(ck_info, f)
+    # A notebook with a 'parameters' cell so we can verify injection
+    nb = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "id": "params",
+                "metadata": {"tags": ["parameters"]},
+                "outputs": [],
+                "source": ["a = 1\n"],
+            },
+            {
+                "cell_type": "code",
+                "execution_count": None,
+                "id": "compute",
+                "metadata": {},
+                "outputs": [],
+                "source": ["result = a * 10\n", "print('result =', result)\n"],
+            },
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    os.makedirs("notebooks")
+    with open(os.path.join("notebooks", "main.ipynb"), "w") as f:
+        json.dump(nb, f)
+    subprocess.check_call(
+        [
+            "calkit",
+            "nb",
+            "exec",
+            "-e",
+            "docker-env",
+            "--no-check",
+            "-p",
+            "a=4",
+            "notebooks/main.ipynb",
+        ]
+    )
+    # The injected parameter should have produced result = 40 in the executed
+    # notebook saved under .calkit/notebooks/executed
+    exec_path = calkit.notebooks.get_executed_notebook_path(
+        notebook_path="notebooks/main.ipynb",
+        to="notebook",
+        parameters={"a": 4},
+    )
+    with open(exec_path) as f:
+        executed = json.load(f)
+    text = "".join(
+        "".join(o.get("text", []))
+        for cell in executed["cells"]
+        for o in cell.get("outputs", [])
+        if o.get("name") == "stdout"
+    )
+    assert "result = 40" in text

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -626,7 +626,7 @@ Model class: `VenvEnvironment`
 | ----------- | --------------- | -------- |
 | kind        | Literal['venv'] | yes      |
 | path        | str             | yes      |
-| prefix      | str             | yes      |
+| prefix      | str             | no       |
 | python      | str             | no       |
 | description | str             | no       |
 
@@ -638,7 +638,7 @@ Model class: `UvVenvEnvironment`
 | ----------- | ------------------ | -------- |
 | kind        | Literal['uv-venv'] | yes      |
 | path        | str                | yes      |
-| prefix      | str                | yes      |
+| prefix      | str                | no       |
 | python      | str                | no       |
 | description | str                | no       |
 
@@ -657,32 +657,24 @@ Model class: `PixiEnvironment`
 
 Model class: `DockerEnvironment`
 
-| Parameter    | Type                           | Required |
-| ------------ | ------------------------------ | -------- |
-| kind         | Literal['docker']              | yes      |
-| image        | str                            | yes      |
-| path         | str                            | no       |
-| platform     | str                            | no       |
-| command_mode | Literal['shell'\|'entrypoint'] | no       |
-| shell        | str                            | no       |
-| deps         | list[str]                      | no       |
-| env_vars     | dict[str, str]                 | no       |
-| ports        | list[str]                      | no       |
-| gpus         | str                            | no       |
-| user         | str                            | no       |
-| wdir         | str                            | no       |
-| args         | list[str]                      | no       |
-| description  | str                            | no       |
-
-#### `renv`
-
-Model class: `REnvironment`
-
-| Parameter   | Type            | Required |
-| ----------- | --------------- | -------- |
-| kind        | Literal['renv'] | yes      |
-| path        | str             | yes      |
-| description | str             | no       |
+| Parameter      | Type                           | Required |
+| -------------- | ------------------------------ | -------- |
+| kind           | Literal['docker']              | yes      |
+| path           | str                            | no       |
+| image          | str                            | yes      |
+| layers         | list[str]                      | no       |
+| shell          | Literal['bash'\|'sh']          | no       |
+| command_mode   | Literal['shell'\|'entrypoint'] | no       |
+| platform       | str                            | no       |
+| wdir           | str                            | no       |
+| user           | str                            | no       |
+| deps           | list[str]                      | no       |
+| env_vars       | dict[str, str]                 | no       |
+| ports          | list[str]                      | no       |
+| gpus           | str                            | no       |
+| args           | list[str]                      | no       |
+| jupyter_kernel | str                            | no       |
+| description    | str                            | no       |
 
 #### `julia`
 
@@ -702,6 +694,7 @@ Model class: `MatlabEnvironment`
 | Parameter   | Type              | Required |
 | ----------- | ----------------- | -------- |
 | kind        | Literal['matlab'] | yes      |
+| version     | str               | no       |
 | products    | list[str]         | no       |
 | description | str               | no       |
 
@@ -709,12 +702,12 @@ Model class: `MatlabEnvironment`
 
 Model class: `NixEnvironment`
 
-| Parameter   | Type                            | Required |
-| ----------- | ------------------------------- | -------- |
-| kind        | Literal['nix']                  | yes      |
-| path        | str (must end with 'flake.nix') | yes      |
-| shell       | str (name of devShell to enter) | no       |
-| description | str                             | no       |
+| Parameter   | Type           | Required |
+| ----------- | -------------- | -------- |
+| kind        | Literal['nix'] | yes      |
+| path        | str            | yes      |
+| shell       | str            | no       |
+| description | str            | no       |
 
 #### `slurm`
 
@@ -727,6 +720,17 @@ Model class: `SlurmEnvironment`
 | default_options | list[str]        | no       |
 | default_setup   | list[str]        | no       |
 | description     | str              | no       |
+
+#### `renv`
+
+Model class: `REnvironment`
+
+| Parameter   | Type            | Required |
+| ----------- | --------------- | -------- |
+| kind        | Literal['renv'] | yes      |
+| path        | str             | yes      |
+| prefix      | str             | yes      |
+| description | str             | no       |
 
 #### `ssh`
 

--- a/scripts/generate-docs-references.py
+++ b/scripts/generate-docs-references.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 import types
 from pathlib import Path
-from typing import Any, get_args, get_origin
+from typing import Any, Union, get_args, get_origin
 
 import click
 import typer
@@ -498,6 +498,62 @@ def _class_doc_lines(cls: type[Any] | None) -> list[str]:
     return lines
 
 
+def _render_field_type(ann: Any) -> str:
+    """Render a Pydantic field annotation as it should appear in the docs.
+
+    Optionality is conveyed by the separate "Required" column, so ``X | None``
+    is rendered as ``X``.
+    """
+    origin = get_origin(ann)
+    if origin is Union or isinstance(ann, types.UnionType):
+        non_none = [a for a in get_args(ann) if a is not type(None)]
+        if len(non_none) == 1:
+            return _render_field_type(non_none[0])
+        return " | ".join(_render_field_type(a) for a in non_none)
+    if origin is not None and str(origin).endswith("Literal"):
+        return "Literal[" + "|".join(repr(v) for v in get_args(ann)) + "]"
+    if origin in (list, set, tuple):
+        inner = ", ".join(_render_field_type(a) for a in get_args(ann))
+        return f"{origin.__name__}[{inner}]"
+    if origin is dict:
+        key_t, val_t = get_args(ann)
+        return (
+            f"dict[{_render_field_type(key_t)}, {_render_field_type(val_t)}]"
+        )
+    if isinstance(ann, type):
+        return ann.__name__
+    return str(ann)
+
+
+# Fields declared on the Environment base; we list them after the
+# kind-specific ones so each table leads with the fields that matter most.
+_ENV_META_FIELDS = ("description",)
+
+
+def _env_rows_from_model(cls: type[Any]) -> list[tuple[str, str, str]]:
+    """Derive doc table rows directly from a Pydantic environment model."""
+    fields = cls.model_fields
+    kind_specific = [
+        name for name in fields if name not in ("kind",) + _ENV_META_FIELDS
+    ]
+    meta = [name for name in _ENV_META_FIELDS if name in fields]
+    ordered = (["kind"] if "kind" in fields else []) + kind_specific + meta
+    rows = []
+    for name in ordered:
+        field = fields[name]
+        # ``kind`` carries a default for convenience but is always required in
+        # a definition, so it's the one field we don't infer from the default.
+        required = name == "kind" or field.is_required()
+        rows.append(
+            (
+                name,
+                _render_field_type(field.annotation),
+                "required" if required else "optional",
+            )
+        )
+    return rows
+
+
 def generate_environment_kinds_markdown() -> str:
     env_classes = [
         Environment,
@@ -521,92 +577,8 @@ def generate_environment_kinds_markdown() -> str:
     }
 
     env_kinds: dict[str, list[tuple[str, str, str]]] = {
-        "conda": [
-            ("kind", "Literal['conda']", "required"),
-            ("path", "str", "required"),
-            ("prefix", "str", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "uv": [
-            ("kind", "Literal['uv']", "required"),
-            ("path", "str", "required"),
-            ("description", "str", "optional"),
-        ],
-        "venv": [
-            ("kind", "Literal['venv']", "required"),
-            ("path", "str", "required"),
-            ("prefix", "str", "required"),
-            ("python", "str", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "uv-venv": [
-            ("kind", "Literal['uv-venv']", "required"),
-            ("path", "str", "required"),
-            ("prefix", "str", "required"),
-            ("python", "str", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "pixi": [
-            ("kind", "Literal['pixi']", "required"),
-            ("path", "str", "required"),
-            ("name", "str", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "docker": [
-            ("kind", "Literal['docker']", "required"),
-            ("image", "str", "required"),
-            ("path", "str", "optional"),
-            ("platform", "str", "optional"),
-            ("command_mode", "Literal['shell'|'entrypoint']", "optional"),
-            ("shell", "str", "optional"),
-            ("deps", "list[str]", "optional"),
-            ("env_vars", "dict[str, str]", "optional"),
-            ("ports", "list[str]", "optional"),
-            ("gpus", "str", "optional"),
-            ("user", "str", "optional"),
-            ("wdir", "str", "optional"),
-            ("args", "list[str]", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "renv": [
-            ("kind", "Literal['renv']", "required"),
-            ("path", "str", "required"),
-            ("description", "str", "optional"),
-        ],
-        "julia": [
-            ("kind", "Literal['julia']", "required"),
-            ("path", "str", "required"),
-            ("julia", "str", "required"),
-            ("description", "str", "optional"),
-        ],
-        "matlab": [
-            ("kind", "Literal['matlab']", "required"),
-            ("products", "list[str]", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "nix": [
-            ("kind", "Literal['nix']", "required"),
-            ("path", "str (must end with 'flake.nix')", "required"),
-            ("shell", "str (name of devShell to enter)", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "slurm": [
-            ("kind", "Literal['slurm']", "required"),
-            ("host", "str", "optional (default: localhost)"),
-            ("default_options", "list[str]", "optional"),
-            ("default_setup", "list[str]", "optional"),
-            ("description", "str", "optional"),
-        ],
-        "ssh": [
-            ("kind", "Literal['ssh']", "required"),
-            ("host", "str", "required"),
-            ("user", "str", "required"),
-            ("wdir", "str", "required"),
-            ("key", "str", "optional"),
-            ("send_paths", "list[str]", "optional"),
-            ("get_paths", "list[str]", "optional"),
-            ("description", "str", "optional"),
-        ],
+        kind: _env_rows_from_model(cls)
+        for kind, cls in env_classes_by_kind.items()
     }
     lines = [
         "### Environment kind reference",


### PR DESCRIPTION
Resolves #961 

This solution runs Papermill inside the container, and we'll install it on the fly if it's not there. This is not great from a reproducibility standpoint, since the version could float, and the environment is not actually the same as it is per the lock file. We could alternatively fail and tell the user they must install Papermill in their Docker image, or we could mutate the image at environment check time.

Something to note for the future: When trying to use these environments interactively in VS Code via the extension, we will fail unless JupyterLab is installed in the image.