### PR TITLE
Add out_dir to LatexStage and modify dvc_outs

### DIFF
--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import shlex
 from pathlib import Path
 from typing import Any, Literal
@@ -557,15 +558,24 @@ class LatexStage(Stage):
     def pdf_path(self) -> str:
         """Path to the compiled PDF.
 
-        When ``output_dir`` is set (e.g. via ``$out_dir`` in a latexmkrc
-        file), latexmk writes the PDF there using the target's base name
-        rather than next to the source ``.tex`` file.
+        Like ``target_path`` and every other Calkit path field, ``output_dir``
+        is relative to the stage's working directory (its ``wdir``, defaulting
+        to the project root), not the LaTeX source directory. The returned path
+        is in that same frame, so it drops straight into ``dvc_outs``. When
+        ``output_dir`` is set, the PDF is written to
+        ``<output_dir>/<target stem>.pdf``; otherwise it sits next to the
+        source ``.tex`` file. This mirrors where latexmk actually writes the
+        PDF when a latexmkrc sets ``$out_dir`` -- see
+        ``_warn_on_latexmkrc_out_dir_mismatch`` in ``calkit.pipeline``, which
+        translates the (source-relative) ``$out_dir`` into this frame and warns
+        when the two disagree.
         """
+        target = Path(self.target_path)
         if self.output_dir is not None:
-            out_base = Path(self.output_dir) / Path(self.target_path).stem
+            out_base = Path(self.output_dir) / target.stem
         else:
-            out_base = Path(self.target_path)
-        return out_base.with_suffix(".pdf").as_posix()
+            out_base = target
+        return Path(os.path.normpath(out_base)).with_suffix(".pdf").as_posix()
 
     @property
     def dvc_cmd(self) -> str:

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -546,12 +546,26 @@ class MapPathsStage(Stage):
 class LatexStage(Stage):
     kind: Literal["latex"] = "latex"
     target_path: str
-    out_dir: str | None = None
+    output_dir: str | None = None
     latexmkrc_path: str | None = None
     pdf_storage: Literal["git", "dvc"] | None = "dvc"
     verbose: bool = False
     force: bool = False
     synctex: bool = True
+
+    @property
+    def pdf_path(self) -> str:
+        """Path to the compiled PDF.
+
+        When ``output_dir`` is set (e.g. via ``$out_dir`` in a latexmkrc
+        file), latexmk writes the PDF there using the target's base name
+        rather than next to the source ``.tex`` file.
+        """
+        if self.output_dir is not None:
+            out_base = Path(self.output_dir) / Path(self.target_path).stem
+        else:
+            out_base = Path(self.target_path)
+        return out_base.with_suffix(".pdf").as_posix()
 
     @property
     def dvc_cmd(self) -> str:
@@ -577,11 +591,7 @@ class LatexStage(Stage):
     @property
     def dvc_outs(self) -> list[str | dict]:
         outs = super().dvc_outs
-        if self.out_dir is not None:
-            out_base = Path(out_dir) / Path(self.target_path).stem
-        else:
-            out_base = Path(self.target_path)
-        out_path = out_base.with_suffix(".pdf").as_posix()
+        out_path = self.pdf_path
         # If the PDF output is already in outs use that
         # Otherwise, create a DVC output from pdf_storage and add it to outs
         out_paths = []

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -546,6 +546,7 @@ class MapPathsStage(Stage):
 class LatexStage(Stage):
     kind: Literal["latex"] = "latex"
     target_path: str
+    out_dir: str | None = None
     latexmkrc_path: str | None = None
     pdf_storage: Literal["git", "dvc"] | None = "dvc"
     verbose: bool = False
@@ -576,9 +577,11 @@ class LatexStage(Stage):
     @property
     def dvc_outs(self) -> list[str | dict]:
         outs = super().dvc_outs
-        out_path = Path(
-            self.target_path.removesuffix(".tex") + ".pdf"
-        ).as_posix()
+        if self.out_dir is not None:
+            out_base = Path(out_dir) / Path(self.target_path).stem
+        else:
+            out_base = Path(self.target_path)
+        out_path = out_base.with_suffix(".pdf").as_posix()
         # If the PDF output is already in outs use that
         # Otherwise, create a DVC output from pdf_storage and add it to outs
         out_paths = []

--- a/calkit/pipeline.py
+++ b/calkit/pipeline.py
@@ -2,6 +2,8 @@
 
 import itertools
 import os
+import re
+import warnings
 from collections.abc import Callable
 from pathlib import Path
 
@@ -12,6 +14,7 @@ import calkit
 from calkit.models.iteration import expand_project_parameters
 from calkit.models.pipeline import (
     InputsFromStageOutputs,
+    LatexStage,
     PathOutput,
     Pipeline,
 )
@@ -1056,6 +1059,158 @@ def _dump_yaml_if_changed(data, fpath: str, verbose: bool = False) -> bool:
     return True
 
 
+def _parse_latexmkrc_var(text: str, var: str) -> str | None:
+    """Extract a literal ``$<var> = '...'`` assignment from latexmkrc text.
+
+    Returns the assigned string for a simple literal assignment (single- or
+    double-quoted), or ``None`` if absent or computed. Anything non-literal
+    is intentionally left for the user rather than guessed at.
+    """
+    match = re.search(
+        r"^\s*\$" + re.escape(var) + r"""\s*=\s*['"]([^'"]*)['"]""",
+        text,
+        flags=re.MULTILINE,
+    )
+    if match is None:
+        return None
+    return match.group(1)
+
+
+def _warn_on_latexmkrc_out_dir_mismatch(
+    stage: LatexStage, wdir: str | None = None
+) -> None:
+    """Warn at compile time if latexmkrc ``$out_dir`` disagrees with the
+    stage's ``output_dir``.
+
+    The tracked PDF output path is derived from ``output_dir``, so a latexmkrc
+    that redirects the PDF without a matching ``output_dir`` would leave the
+    real PDF untracked. Because ``calkit latex build`` runs latexmk with
+    ``-cd``, the latexmkrc's ``$out_dir`` is relative to the LaTeX source
+    directory, whereas ``output_dir`` (like all Calkit path fields) is relative
+    to the stage's working directory; we resolve the former into that same
+    frame before comparing. We only read the file when a latexmkrc is
+    referenced (rare), so there is no cost on the common path.
+    """
+    if stage.latexmkrc_path is None:
+        return
+    # Stage path fields are relative to the stage's wdir, which in turn is
+    # relative to the (sub)project being compiled.
+    base = os.path.join(wdir or ".", stage.wdir) if stage.wdir else wdir or "."
+    try:
+        with open(os.path.join(base, stage.latexmkrc_path)) as f:
+            text = f.read()
+    except OSError:
+        return
+    rc_out_dir = _parse_latexmkrc_var(text, "out_dir")
+    if rc_out_dir is None:
+        # Absent or computed (non-literal): nothing reliable to compare.
+        return
+    source_dir = os.path.dirname(stage.target_path)
+    # Resolve the source-relative $out_dir into the stage's path frame (the
+    # same frame as output_dir). An empty or "." $out_dir means "next to the
+    # source", which is what output_dir=None also means.
+    rc_resolved = os.path.normpath(os.path.join(source_dir or ".", rc_out_dir))
+    next_to_source = os.path.normpath(source_dir or ".")
+    if stage.output_dir is None:
+        declared = next_to_source
+    else:
+        declared = os.path.normpath(stage.output_dir)
+    if rc_resolved == declared:
+        return
+    if rc_resolved == next_to_source:
+        fix = "remove output_dir (the PDF is written next to the source)"
+    else:
+        fix = f"set output_dir: {rc_resolved}"
+    warnings.warn(
+        f"LaTeX stage '{stage.name}': latexmkrc '{stage.latexmkrc_path}' "
+        f"sets $out_dir={rc_out_dir!r} (relative to the source, i.e. "
+        f"{rc_resolved!r} in the stage's path frame), but the stage's "
+        f"output_dir is {stage.output_dir!r}. The tracked PDF output path is "
+        "derived from output_dir, so these should agree or the compiled PDF "
+        f"may not be tracked. {fix}.",
+        stacklevel=2,
+    )
+
+
+def _ensure_latex_aux_gitignore(
+    stage: LatexStage, wdir: str | None = None
+) -> bool:
+    """Ensure a managed ``.gitignore`` block ignores LaTeX aux files.
+
+    The block lives in the LaTeX source directory's ``.gitignore`` rather than
+    inside the build/output directory, which may not exist at compile time and
+    can be wiped by a clean build (``latexmk -C``). The globs are unanchored,
+    so aux files are caught wherever latexmk writes them relative to the
+    source -- next to it, or in an ``aux``/output subdirectory via
+    ``$aux_dir``/``$out_dir``/``output_dir``. ``*.pdf`` is never ignored so the
+    compiled output stays tracked.
+
+    Returns True if ``.gitignore`` was modified.
+    """
+    aux_globs = [
+        "*.aux",
+        "*.bbl",
+        "*.bcf",
+        "*.blg",
+        "*.fdb_latexmk",
+        "*.fls",
+        "*.lof",
+        "*.lot",
+        "*.nav",
+        "*.out",
+        "*.run.xml",
+        "*.snm",
+        "*.synctex.gz",
+        "*.toc",
+        "*.vrb",
+    ]
+    # Stage path fields are relative to the stage's wdir, which in turn is
+    # relative to the (sub)project being compiled.
+    base = os.path.join(wdir or ".", stage.wdir) if stage.wdir else wdir or "."
+    source_dir = os.path.dirname(stage.target_path)
+    gitignore_path = os.path.join(base, source_dir, ".gitignore")
+    return _write_managed_gitignore_block(
+        gitignore_path, marker="calkit latex aux files", lines=aux_globs
+    )
+
+
+def _write_managed_gitignore_block(
+    gitignore_path: str, marker: str, lines: list[str]
+) -> bool:
+    """Create or update a marker-delimited block in a ``.gitignore`` file.
+
+    The block is replaced in place if it already exists (so it stays free of
+    duplicate/stale entries across recompiles) and appended otherwise.
+    Returns True if the file was modified.
+    """
+    begin = f"# >>> {marker} (managed by calkit) >>>"
+    end = f"# <<< {marker} <<<"
+    block = "\n".join([begin] + lines + [end])
+    existing = ""
+    if os.path.isfile(gitignore_path):
+        with open(gitignore_path) as f:
+            existing = f.read()
+    block_re = re.compile(
+        re.escape(begin) + r".*?" + re.escape(end), flags=re.DOTALL
+    )
+    if block_re.search(existing):
+        updated = block_re.sub(lambda _: block, existing)
+        if updated == existing:
+            return False
+        with open(gitignore_path, "w") as f:
+            f.write(updated)
+        return True
+    parent = os.path.dirname(gitignore_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    separator = (
+        "" if not existing else ("\n" if existing.endswith("\n") else "\n\n")
+    )
+    with open(gitignore_path, "a") as f:
+        f.write(separator + block + "\n")
+    return True
+
+
 def to_dvc(
     ck_info: dict | None = None,
     wdir: str | None = None,
@@ -1110,8 +1265,6 @@ def to_dvc(
             continue
         isolated_sp_paths.append(sp)
         if not sp_dvc_stages:
-            import warnings
-
             warnings.warn(
                 f"Subproject '{sp}' has no pipeline stages defined; "
                 "no wrapper stage will be created.",
@@ -1369,6 +1522,14 @@ def to_dvc(
                 elif isinstance(out, PathOutput) and out.storage == "dvc-zip":
                     calkit.git.ensure_path_is_ignored(repo, path=out.path)
                     calkit.dvc.zip.add(out.path, is_stage_output=True)
+        # For LaTeX stages, warn on a latexmkrc/output_dir mismatch and keep
+        # the generated aux files out of Git via a managed .gitignore block.
+        # Globs (not per-file git check-ignore) keep this cheap for large
+        # pipelines.
+        if write and isinstance(stage, LatexStage):
+            _warn_on_latexmkrc_out_dir_mismatch(stage, wdir=wdir)
+            if manage_gitignore:
+                _ensure_latex_aux_gitignore(stage, wdir=wdir)
     # Now process any inputs from stage outputs
     for stage_name, stage in pipeline.stages.items():
         for i in stage.inputs:

--- a/calkit/pipeline.py
+++ b/calkit/pipeline.py
@@ -1108,7 +1108,8 @@ def _warn_on_latexmkrc_out_dir_mismatch(
     source_dir = os.path.dirname(stage.target_path)
     # Resolve the source-relative $out_dir into the stage's path frame (the
     # same frame as output_dir). An empty or "." $out_dir means "next to the
-    # source", which is what output_dir=None also means.
+    # source", which is what output_dir=None also means. Comparison uses native
+    # os.path; the resolved value is converted to POSIX only for display.
     rc_resolved = os.path.normpath(os.path.join(source_dir or ".", rc_out_dir))
     next_to_source = os.path.normpath(source_dir or ".")
     if stage.output_dir is None:
@@ -1117,17 +1118,18 @@ def _warn_on_latexmkrc_out_dir_mismatch(
         declared = os.path.normpath(stage.output_dir)
     if rc_resolved == declared:
         return
+    rc_posix = Path(rc_resolved).as_posix()
     if rc_resolved == next_to_source:
         fix = "remove output_dir (the PDF is written next to the source)"
     else:
-        fix = f"set output_dir: {rc_resolved}"
+        fix = f"set output_dir: {rc_posix}"
     warnings.warn(
         f"LaTeX stage '{stage.name}': latexmkrc '{stage.latexmkrc_path}' "
         f"sets $out_dir={rc_out_dir!r} (relative to the source, i.e. "
-        f"{rc_resolved!r} in the stage's path frame), but the stage's "
-        f"output_dir is {stage.output_dir!r}. The tracked PDF output path is "
-        "derived from output_dir, so these should agree or the compiled PDF "
-        f"may not be tracked. {fix}.",
+        f"{rc_posix!r} in the stage's path frame), but the stage's output_dir "
+        f"is {stage.output_dir!r}. The tracked PDF output path is derived from "
+        "output_dir, so these should agree or the compiled PDF may not be "
+        f"tracked. {fix}.",
         stacklevel=2,
     )
 

--- a/calkit/tests/models/test_pipeline.py
+++ b/calkit/tests/models/test_pipeline.py
@@ -104,8 +104,8 @@ def test_latexstage():
     )
     assert s.pdf_path == "paper/my-paper.pdf"
     assert "paper/my-paper.pdf" in s.dvc_outs
-    # With an output_dir (e.g. $out_dir in latexmkrc), latexmk writes the PDF
-    # into that directory using the target's base name
+    # output_dir is relative to the project root (like every other Calkit path
+    # field), so the PDF lands in <output_dir>/<stem>.pdf
     s = LatexStage(
         name="something",
         environment="tex",
@@ -121,16 +121,16 @@ def test_latexstage():
         name="something",
         environment="tex",
         target_path="paper/my-paper.tex",
-        output_dir="build",
+        output_dir="paper/build",
         pdf_storage="git",
     )
-    assert s.dvc_outs == [{"build/my-paper.pdf": {"cache": False}}]
-    # An output_dir relative to the document root resolves cleanly
+    assert s.dvc_outs == [{"paper/build/my-paper.pdf": {"cache": False}}]
+    # A trailing-slash / redundant "." segment normalizes cleanly
     s = LatexStage(
         name="something",
         environment="tex",
         target_path="my-paper.tex",
-        output_dir="build",
+        output_dir="./build/",
     )
     assert s.pdf_path == "build/my-paper.pdf"
 
@@ -145,8 +145,7 @@ def test_quartostage():
     )
     sd = s.to_dvc()
     assert sd["cmd"] == (
-        "calkit xenv -n analysis --no-check -- "
-        "quarto render report/report.qmd"
+        "calkit xenv -n analysis --no-check -- quarto render report/report.qmd"
     )
     assert "report/report.qmd" in sd["deps"]
     assert "report/results.json" in sd["deps"]

--- a/calkit/tests/models/test_pipeline.py
+++ b/calkit/tests/models/test_pipeline.py
@@ -96,6 +96,43 @@ def test_latexstage():
         outputs=["my-paper.pdf"],
     )
     assert s.dvc_outs == ["my-paper.pdf"]
+    # With no output_dir, the PDF sits next to the source
+    s = LatexStage(
+        name="something",
+        environment="tex",
+        target_path="paper/my-paper.tex",
+    )
+    assert s.pdf_path == "paper/my-paper.pdf"
+    assert "paper/my-paper.pdf" in s.dvc_outs
+    # With an output_dir (e.g. $out_dir in latexmkrc), latexmk writes the PDF
+    # into that directory using the target's base name
+    s = LatexStage(
+        name="something",
+        environment="tex",
+        target_path="paper/my-paper.tex",
+        output_dir="paper/build",
+    )
+    assert s.pdf_path == "paper/build/my-paper.pdf"
+    assert "paper/build/my-paper.pdf" in s.dvc_outs
+    # The source path's .pdf is not assumed when output_dir is set
+    assert "paper/my-paper.pdf" not in s.dvc_outs
+    # output_dir is respected for git-stored PDFs too
+    s = LatexStage(
+        name="something",
+        environment="tex",
+        target_path="paper/my-paper.tex",
+        output_dir="build",
+        pdf_storage="git",
+    )
+    assert s.dvc_outs == [{"build/my-paper.pdf": {"cache": False}}]
+    # An output_dir relative to the document root resolves cleanly
+    s = LatexStage(
+        name="something",
+        environment="tex",
+        target_path="my-paper.tex",
+        output_dir="build",
+    )
+    assert s.pdf_path == "build/my-paper.pdf"
 
 
 def test_quartostage():

--- a/calkit/tests/test_pipeline.py
+++ b/calkit/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import warnings
 
 import git
 import pytest
@@ -9,10 +10,13 @@ import pytest
 import calkit
 import calkit.pipeline
 from calkit.environments import get_env_lock_fpath
+from calkit.models.pipeline import LatexStage
 from calkit.pipeline import (
     StaleStage,
+    _ensure_latex_aux_gitignore,
     _expand_dep_excluding_subprojects,
     _status_target_matches,
+    _warn_on_latexmkrc_out_dir_mismatch,
     collapse_dvc_stages,
     stages_are_similar,
 )
@@ -1416,8 +1420,14 @@ def test_gitignore_not_unignored_latex_pdf_output(tmp_dir):
     calkit.pipeline.to_dvc(ck_info=ck_info, write=True)
     assert not os.path.exists(".gitignore")
     with open("paper/.gitignore") as f:
-        assert f.read().splitlines() == ["/main.pdf"]
+        lines = f.read().splitlines()
+    # The user's PDF ignore entry is preserved (not unignored on recompile)
+    assert "/main.pdf" in lines
     assert repo.ignored("paper/main.pdf")
+    # The managed aux-file block is added, but never ignores the PDF
+    assert "# >>> calkit latex aux files (managed by calkit) >>>" in lines
+    assert "*.aux" in lines
+    assert "*.pdf" not in lines
 
 
 def test_get_status(tmp_dir):
@@ -2280,3 +2290,107 @@ def test_reproduce_targets_concurrently():
         "work@e": 0,
     }
     assert state["peak"] == 2
+
+
+def test_warn_on_latexmkrc_out_dir_mismatch(tmp_dir):
+    os.makedirs("paper")
+    rc_path = "paper/.latexmkrc"
+    stage = LatexStage(
+        name="build-paper",
+        environment="tex",
+        target_path="paper/main.tex",
+        latexmkrc_path=rc_path,
+    )
+    # latexmkrc redirects the PDF but output_dir is unset. $out_dir is
+    # source-relative (latexmk -cd), so 'build' resolves to 'paper/build'
+    # from the project root; the warning suggests that project-root value.
+    with open(rc_path, "w") as f:
+        f.write("$out_dir = 'build';\n$aux_dir = 'aux';\n")
+    with pytest.warns(UserWarning, match=r"output_dir: paper/build"):
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # A bare source-relative value in output_dir is still flagged (it would be
+    # interpreted as project-root 'build', not 'paper/build')
+    stage.output_dir = "build"
+    with pytest.warns(UserWarning, match=r"output_dir: paper/build"):
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # When output_dir matches the resolved project-root path, no warning
+    stage.output_dir = "paper/build"
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # $out_dir = '.' means "next to the source" == output_dir unset; a
+    # non-None output_dir is flagged with advice to remove it
+    stage.output_dir = "paper/build"
+    with open(rc_path, "w") as f:
+        f.write("$out_dir = '.';\n")
+    with pytest.warns(UserWarning, match=r"remove output_dir"):
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # $out_dir = '.' with output_dir unset -> no warning
+    stage.output_dir = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # A computed (non-literal) $out_dir is left alone -> no warning
+    with open(rc_path, "w") as f:
+        f.write("$out_dir = $ENV{BUILD_DIR};\n")
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+    # No latexmkrc referenced -> no file read, no warning
+    stage.latexmkrc_path = None
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        _warn_on_latexmkrc_out_dir_mismatch(stage)
+
+
+def test_ensure_latex_aux_gitignore(tmp_dir):
+    os.makedirs("paper")
+    stage = LatexStage(
+        name="build-paper",
+        environment="tex",
+        target_path="paper/main.tex",
+    )
+    # A pre-existing, unrelated .gitignore entry that must be preserved
+    gitignore_path = os.path.join("paper", ".gitignore")
+    with open(gitignore_path, "w") as f:
+        f.write("figs/*.png\n")
+    # The managed block is written to the document directory's .gitignore
+    changed = _ensure_latex_aux_gitignore(stage)
+    assert changed
+    with open(gitignore_path) as f:
+        contents = f.read()
+    assert "figs/*.png" in contents
+    assert "*.aux" in contents
+    assert "*.fdb_latexmk" in contents
+    assert "*.synctex.gz" in contents
+    # The compiled PDF must never be ignored
+    assert "*.pdf" not in contents
+    assert "managed by calkit" in contents
+    assert contents.count("# >>> calkit latex aux files") == 1
+    # Idempotent: re-running makes no change
+    assert _ensure_latex_aux_gitignore(stage) is False
+    # The globs are unanchored regardless of output_dir, so they catch aux
+    # files in an output/aux subdirectory too; output_dir does not change the
+    # written patterns (it is handled by pdf_path/the lint, not the gitignore)
+    stage.output_dir = "paper/build"
+    assert _ensure_latex_aux_gitignore(stage) is False
+    with open(gitignore_path) as f:
+        contents = f.read()
+    assert "*.aux" in contents
+    assert "*.pdf" not in contents
+    # The block is not duplicated and the unrelated entry survives
+    assert contents.count("# >>> calkit latex aux files") == 1
+    assert "figs/*.png" in contents
+    # When the stage has a wdir, paths are relative to it, so the .gitignore
+    # lands under <wdir>/<source dir>, not the project root
+    os.makedirs("sub/doc")
+    wdir_stage = LatexStage(
+        name="build-sub",
+        environment="tex",
+        wdir="sub",
+        target_path="doc/main.tex",
+    )
+    assert _ensure_latex_aux_gitignore(wdir_stage)
+    assert not os.path.exists(os.path.join("doc", ".gitignore"))
+    with open(os.path.join("sub", "doc", ".gitignore")) as f:
+        assert "*.aux" in f.read()

--- a/docs/pipeline/index.md
+++ b/docs/pipeline/index.md
@@ -358,6 +358,7 @@ Model class: `LatexStage`
 | Kind-specific parameter | Type                          | Required | Default |
 | ----------------------- | ----------------------------- | -------- | ------- |
 | `target_path`           | str                           | yes      |         |
+| `output_dir`            | str \| None                   | no       | null    |
 | `latexmkrc_path`        | str \| None                   | no       | null    |
 | `pdf_storage`           | Literal['git', 'dvc'] \| None | no       | 'dvc'   |
 | `verbose`               | bool                          | no       | False   |


### PR DESCRIPTION
Add optional out_dir attribute and update dvc_outs method to handle output directory. This is required to have the correct dvc_outs when running with an outdir set in latexmkrc.