### PR TITLE
Fix calkit init to detect existing initialization and require --force

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -179,12 +179,22 @@ def init(
         typer.Option(
             "--force",
             "-f",
-            help=("Re-initialize even if the project is already initialized."),
+            help="Re-initialize even if the project is already initialized.",
         ),
     ] = False,
 ):
     """Initialize the current working directory."""
-    if os.path.isfile("calkit.yaml") and not force:
+    import git
+    from git.exc import InvalidGitRepositoryError
+
+    def _project_is_initialized() -> bool:
+        try:
+            git.Repo(".", search_parent_directories=False)
+        except InvalidGitRepositoryError:
+            return False
+        return os.path.isfile(".dvc/config") and os.path.isfile("calkit.yaml")
+
+    if _project_is_initialized() and not force:
         raise_error(
             "This project is already initialized. "
             "Use --force to re-initialize."
@@ -202,13 +212,15 @@ def init(
     # Commit the newly created .dvc directory
     repo = calkit.git.get_repo()
     repo.git.add(".dvc")
-    repo.git.commit("-m", "Initialize DVC")
+    if calkit.git.get_staged_files(repo=repo):
+        repo.git.commit("-m", "Initialize DVC")
     # Create an empty calkit.yaml if one doesn't already exist
     if not os.path.isfile("calkit.yaml"):
         with open("calkit.yaml", "w"):
             pass
         repo.git.add("calkit.yaml")
-        repo.git.commit("-m", "Initialize Calkit")
+        if calkit.git.get_staged_files(repo=repo):
+            repo.git.commit("-m", "Initialize Calkit")
     # TODO: Initialize `dvc.yaml`
     # TODO: Add a sane .gitignore file
     # TODO: Add a sane LICENSE file?

--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -179,11 +179,16 @@ def init(
         typer.Option(
             "--force",
             "-f",
-            help="Force reinitializing DVC if already initialized.",
+            help=("Re-initialize even if the project is already initialized."),
         ),
     ] = False,
 ):
     """Initialize the current working directory."""
+    if os.path.isfile("calkit.yaml") and not force:
+        raise_error(
+            "This project is already initialized. "
+            "Use --force to re-initialize."
+        )
     subprocess.run(["git", "init"])
     result = calkit.dvc.run_dvc_command(
         ["init"] + (["--force"] if force else [])

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -60,12 +60,32 @@ def test_init(tmp_dir):
     subprocess.check_call(["calkit", "init"])
     assert os.path.isfile("calkit.yaml")
     assert calkit.load_calkit_info() == {}
-    # init must not clobber a pre-existing calkit.yaml
+    # Already initialized: init without --force fails and does not clobber
+    result = subprocess.run(
+        ["calkit", "init"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "already initialized" in result.stderr.lower()
+    assert "use --force" in result.stderr.lower()
+    assert calkit.load_calkit_info() == {}
+    # Pre-existing calkit.yaml blocks init without --force
     os.makedirs("sub")
     ck_info = {"name": "test-project"}
     with open(os.path.join("sub", "calkit.yaml"), "w") as f:
         calkit.ryaml.dump(ck_info, f)
-    subprocess.check_call(["calkit", "init"], cwd="sub")
+    result = subprocess.run(
+        ["calkit", "init"],
+        cwd="sub",
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "already initialized" in result.stderr.lower()
+    assert calkit.load_calkit_info(wdir="sub") == ck_info
+    # --force allows re-initialization without clobbering calkit.yaml
+    subprocess.check_call(["calkit", "init", "--force"], cwd="sub")
     assert calkit.load_calkit_info(wdir="sub") == ck_info
 
 

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -70,11 +70,14 @@ def test_init(tmp_dir):
     assert "already initialized" in result.stderr.lower()
     assert "use --force" in result.stderr.lower()
     assert calkit.load_calkit_info() == {}
-    # Pre-existing calkit.yaml blocks init without --force
+    # init must not clobber a pre-existing calkit.yaml
     os.makedirs("sub")
     ck_info = {"name": "test-project"}
     with open(os.path.join("sub", "calkit.yaml"), "w") as f:
         calkit.ryaml.dump(ck_info, f)
+    subprocess.check_call(["calkit", "init"], cwd="sub")
+    assert calkit.load_calkit_info(wdir="sub") == ck_info
+    # Fully initialized project blocks init without --force
     result = subprocess.run(
         ["calkit", "init"],
         cwd="sub",


### PR DESCRIPTION
Closes #391

## What changed
`calkit init` now detects when the current directory is already an initialized
Calkit project and exits with a clear error instead of silently re-initializing.
Passing `--force` re-initializes as before.

## Why
Previously, running `calkit init` in an already-initialized project would re-run
and overwrite existing state without warning.

## Behavior
- `calkit init` in an already-initialized project → exits with a non-zero code and
  the message: `This project is already initialized. Use --force to re-initialize.`
- `calkit init --force` → re-initializes as before.
- `calkit init` in a fresh, uninitialized directory → unchanged.

## Testing
- Added a test in `calkit/tests/cli/main/test_core.py` covering the
  already-initialized case (with and without `--force`) and the fresh-directory case.
- `uv run pytest calkit/tests/cli/main/test_core.py::test_init` passes locally.