### PR TITLE
Add an artifact ignore file

### DIFF
--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -3174,7 +3174,8 @@ def new_release(
         detected_kind, artifact = calkit.releases.find_artifact(path, ck_info)
         if detected_kind is None:
             detected_kind = calkit.detect.detect_artifact_kind(
-                pathlib.Path(path).as_posix()
+                pathlib.Path(path).as_posix(),
+                ignore=calkit.detect.load_detection_ignore(),
             )
         if release_kind is None:
             if detected_kind is None:

--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -3175,7 +3175,6 @@ def new_release(
         if detected_kind is None:
             detected_kind = calkit.detect.detect_artifact_kind(
                 pathlib.Path(path).as_posix(),
-                ignore=calkit.detect.load_detection_ignore(),
             )
         if release_kind is None:
             if detected_kind is None:

--- a/calkit/detect.py
+++ b/calkit/detect.py
@@ -11,7 +11,10 @@ import re
 import shlex
 import sys
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    import pathspec
 
 NotebookLanguage = Literal["python", "julia", "r"]
 
@@ -1949,41 +1952,20 @@ PRESENTATION_NAMES = {
     "talk.pdf",
 }
 
-DETECTION_IGNORE_FPATH = os.path.join(".calkit", "ignore.json")
+DETECTION_IGNORE_FPATH = os.path.join(".calkit", "ignore")
 
 
-def load_detection_ignore(wdir: str | None = None) -> dict[str, dict]:
-    """Load ``.calkit/ignore.json`` artifact detection exclusions.
+def _load_ignore_spec(wdir: str | None = None) -> "pathspec.PathSpec | None":
+    """Load ``.calkit/ignore`` artifact detection exclusions."""
+    import pathspec
 
-    Returns an empty mapping when the file is absent. Raises ``ValueError`` when
-    the file exists but is not valid JSON.
-    """
     fpath = DETECTION_IGNORE_FPATH
     if wdir is not None:
         fpath = os.path.join(wdir, fpath)
     if not os.path.isfile(fpath):
-        return {}
-    try:
-        with open(fpath, encoding="utf-8") as f:
-            data = json.load(f)
-    except json.JSONDecodeError as e:
-        raise ValueError(f"Invalid JSON in {fpath}: {e}") from e
-    if not isinstance(data, dict):
-        return {}
-    return data
-
-
-def _is_excluded_from_kind(
-    rel_path: str, kind: str, ignore: dict[str, dict]
-) -> bool:
-    """Whether ``rel_path`` must not be auto-detected as ``kind``."""
-    entry = ignore.get(rel_path)
-    if not isinstance(entry, dict):
-        return False
-    not_kinds = entry.get("not")
-    if not isinstance(not_kinds, list):
-        return False
-    return kind in not_kinds
+        return None
+    with open(fpath, encoding="utf-8") as f:
+        return pathspec.PathSpec.from_lines("gitwildmatch", f)
 
 
 def _ancestor_dir_names(rel_path: str) -> set[str]:
@@ -1997,10 +1979,10 @@ def _path_ext(rel_path: str) -> str:
 
 
 def is_figure_path(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable figure."""
-    if ignore and _is_excluded_from_kind(rel_path, "figure", ignore):
+    if ignore is not None and ignore.match_file(rel_path):
         return False
     ancestors = _ancestor_dir_names(rel_path)
     ext = _path_ext(rel_path)
@@ -2014,10 +1996,10 @@ def is_figure_path(
 
 
 def is_dataset_path(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable dataset."""
-    if ignore and _is_excluded_from_kind(rel_path, "dataset", ignore):
+    if ignore is not None and ignore.match_file(rel_path):
         return False
     return (
         _path_ext(rel_path) in DATASET_EXTENSIONS
@@ -2027,14 +2009,14 @@ def is_dataset_path(
 
 
 def is_result_path(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable result.
 
     A result is a data-like file (JSON, CSV, etc.) under a ``results``-style
     directory. Anything already detected as a figure or dataset is excluded.
     """
-    if ignore and _is_excluded_from_kind(rel_path, "result", ignore):
+    if ignore is not None and ignore.match_file(rel_path):
         return False
     return (
         _path_ext(rel_path) in RESULT_EXTENSIONS
@@ -2045,7 +2027,7 @@ def is_result_path(
 
 
 def is_presentation_path(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable presentation.
 
@@ -2053,7 +2035,7 @@ def is_presentation_path(
     directory, or a file with a presentation-like name (e.g. ``slides.pdf``,
     ``presentation.pdf``) anywhere. Figures are excluded.
     """
-    if ignore and _is_excluded_from_kind(rel_path, "presentation", ignore):
+    if ignore is not None and ignore.match_file(rel_path):
         return False
     if is_figure_path(rel_path, ignore=ignore):
         return False
@@ -2093,7 +2075,7 @@ PUBLICATION_NAMES = {
 
 
 def is_publication_path(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable publication.
 
@@ -2102,7 +2084,7 @@ def is_publication_path(
     ``manuscript.pdf``, ``main.tex``) anywhere. Figures and presentations are
     excluded.
     """
-    if ignore and _is_excluded_from_kind(rel_path, "publication", ignore):
+    if ignore is not None and ignore.match_file(rel_path):
         return False
     if is_figure_path(rel_path, ignore=ignore) or is_presentation_path(
         rel_path, ignore=ignore
@@ -2117,7 +2099,7 @@ def is_publication_path(
 
 
 def detect_artifact_kind(
-    rel_path: str, *, ignore: dict[str, dict] | None = None
+    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
 ) -> str | None:
     """Infer an artifact's release kind from its repo-relative path.
 
@@ -2172,7 +2154,7 @@ def _collapse_dataset_folders(paths: list[str]) -> list[str]:
 def detect_figures(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: dict[str, dict] | None = None,
+    ignore: "pathspec.PathSpec | None" = None,
 ) -> list[str]:
     """Auto-detected figure paths among ``candidate_paths``.
 
@@ -2195,7 +2177,7 @@ def detect_datasets(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
     figure_paths: list[str] | tuple[str, ...] = (),
-    ignore: dict[str, dict] | None = None,
+    ignore: "pathspec.PathSpec | None" = None,
 ) -> list[str]:
     """Auto-detected dataset paths among ``candidate_paths``.
 
@@ -2218,7 +2200,7 @@ def detect_datasets(
 def detect_results(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: dict[str, dict] | None = None,
+    ignore: "pathspec.PathSpec | None" = None,
 ) -> list[str]:
     """Auto-detected result paths among ``candidate_paths``.
 
@@ -2240,7 +2222,7 @@ def detect_results(
 def detect_presentations(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: dict[str, dict] | None = None,
+    ignore: "pathspec.PathSpec | None" = None,
 ) -> list[str]:
     """Auto-detected presentation paths among ``candidate_paths``."""
     reserved = list(reserved_paths)
@@ -2340,7 +2322,7 @@ def detect_project_artifacts(
 
     if ck_info is None:
         ck_info = calkit.load_calkit_info(wdir=wdir)
-    ignore = load_detection_ignore(wdir=wdir)
+    ignore = _load_ignore_spec(wdir=wdir)
     reserved = _reserved_artifact_paths(wdir=wdir, ck_info=ck_info)
     candidates = list(
         dict.fromkeys(

--- a/calkit/detect.py
+++ b/calkit/detect.py
@@ -11,10 +11,9 @@ import re
 import shlex
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 
-if TYPE_CHECKING:
-    import pathspec
+import pathspec
 
 NotebookLanguage = Literal["python", "julia", "r"]
 
@@ -1955,7 +1954,7 @@ PRESENTATION_NAMES = {
 DETECTION_IGNORE_FPATH = os.path.join(".calkit", "ignore")
 
 
-def _load_ignore_spec(wdir: str | None = None) -> "pathspec.PathSpec | None":
+def load_detection_ignore(wdir: str | None = None) -> pathspec.PathSpec | None:
     """Load ``.calkit/ignore`` artifact detection exclusions."""
     import pathspec
 
@@ -1979,7 +1978,7 @@ def _path_ext(rel_path: str) -> str:
 
 
 def is_figure_path(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable figure."""
     if ignore is not None and ignore.match_file(rel_path):
@@ -1996,7 +1995,7 @@ def is_figure_path(
 
 
 def is_dataset_path(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable dataset."""
     if ignore is not None and ignore.match_file(rel_path):
@@ -2009,7 +2008,7 @@ def is_dataset_path(
 
 
 def is_result_path(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable result.
 
@@ -2027,7 +2026,7 @@ def is_result_path(
 
 
 def is_presentation_path(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable presentation.
 
@@ -2075,7 +2074,7 @@ PUBLICATION_NAMES = {
 
 
 def is_publication_path(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> bool:
     """Whether a repo-relative path looks like an auto-detectable publication.
 
@@ -2099,7 +2098,7 @@ def is_publication_path(
 
 
 def detect_artifact_kind(
-    rel_path: str, *, ignore: "pathspec.PathSpec | None" = None
+    rel_path: str, *, ignore: pathspec.PathSpec | None = None
 ) -> str | None:
     """Infer an artifact's release kind from its repo-relative path.
 
@@ -2154,7 +2153,7 @@ def _collapse_dataset_folders(paths: list[str]) -> list[str]:
 def detect_figures(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: "pathspec.PathSpec | None" = None,
+    ignore: pathspec.PathSpec | None = None,
 ) -> list[str]:
     """Auto-detected figure paths among ``candidate_paths``.
 
@@ -2177,7 +2176,7 @@ def detect_datasets(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
     figure_paths: list[str] | tuple[str, ...] = (),
-    ignore: "pathspec.PathSpec | None" = None,
+    ignore: pathspec.PathSpec | None = None,
 ) -> list[str]:
     """Auto-detected dataset paths among ``candidate_paths``.
 
@@ -2200,7 +2199,7 @@ def detect_datasets(
 def detect_results(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: "pathspec.PathSpec | None" = None,
+    ignore: pathspec.PathSpec | None = None,
 ) -> list[str]:
     """Auto-detected result paths among ``candidate_paths``.
 
@@ -2222,7 +2221,7 @@ def detect_results(
 def detect_presentations(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
-    ignore: "pathspec.PathSpec | None" = None,
+    ignore: pathspec.PathSpec | None = None,
 ) -> list[str]:
     """Auto-detected presentation paths among ``candidate_paths``."""
     reserved = list(reserved_paths)
@@ -2322,7 +2321,7 @@ def detect_project_artifacts(
 
     if ck_info is None:
         ck_info = calkit.load_calkit_info(wdir=wdir)
-    ignore = _load_ignore_spec(wdir=wdir)
+    ignore = load_detection_ignore(wdir=wdir)
     reserved = _reserved_artifact_paths(wdir=wdir, ck_info=ck_info)
     candidates = list(
         dict.fromkeys(

--- a/calkit/detect.py
+++ b/calkit/detect.py
@@ -1949,6 +1949,42 @@ PRESENTATION_NAMES = {
     "talk.pdf",
 }
 
+DETECTION_IGNORE_FPATH = os.path.join(".calkit", "ignore.json")
+
+
+def load_detection_ignore(wdir: str | None = None) -> dict[str, dict]:
+    """Load ``.calkit/ignore.json`` artifact detection exclusions.
+
+    Returns an empty mapping when the file is absent. Raises ``ValueError`` when
+    the file exists but is not valid JSON.
+    """
+    fpath = DETECTION_IGNORE_FPATH
+    if wdir is not None:
+        fpath = os.path.join(wdir, fpath)
+    if not os.path.isfile(fpath):
+        return {}
+    try:
+        with open(fpath, encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in {fpath}: {e}") from e
+    if not isinstance(data, dict):
+        return {}
+    return data
+
+
+def _is_excluded_from_kind(
+    rel_path: str, kind: str, ignore: dict[str, dict]
+) -> bool:
+    """Whether ``rel_path`` must not be auto-detected as ``kind``."""
+    entry = ignore.get(rel_path)
+    if not isinstance(entry, dict):
+        return False
+    not_kinds = entry.get("not")
+    if not isinstance(not_kinds, list):
+        return False
+    return kind in not_kinds
+
 
 def _ancestor_dir_names(rel_path: str) -> set[str]:
     """Lower-cased names of the ancestor directories of a "/"-separated path."""
@@ -1960,8 +1996,12 @@ def _path_ext(rel_path: str) -> str:
     return ("." + name.rsplit(".", 1)[-1].lower()) if "." in name else ""
 
 
-def is_figure_path(rel_path: str) -> bool:
+def is_figure_path(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> bool:
     """Whether a repo-relative path looks like an auto-detectable figure."""
+    if ignore and _is_excluded_from_kind(rel_path, "figure", ignore):
+        return False
     ancestors = _ancestor_dir_names(rel_path)
     ext = _path_ext(rel_path)
     if ext in FIGURE_EXTENSIONS and ancestors & FIGURE_DIRS:
@@ -1973,37 +2013,49 @@ def is_figure_path(rel_path: str) -> bool:
     return False
 
 
-def is_dataset_path(rel_path: str) -> bool:
+def is_dataset_path(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> bool:
     """Whether a repo-relative path looks like an auto-detectable dataset."""
+    if ignore and _is_excluded_from_kind(rel_path, "dataset", ignore):
+        return False
     return (
         _path_ext(rel_path) in DATASET_EXTENSIONS
         and bool(_ancestor_dir_names(rel_path) & DATA_DIRS)
-        and not is_figure_path(rel_path)
+        and not is_figure_path(rel_path, ignore=ignore)
     )
 
 
-def is_result_path(rel_path: str) -> bool:
+def is_result_path(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> bool:
     """Whether a repo-relative path looks like an auto-detectable result.
 
     A result is a data-like file (JSON, CSV, etc.) under a ``results``-style
     directory. Anything already detected as a figure or dataset is excluded.
     """
+    if ignore and _is_excluded_from_kind(rel_path, "result", ignore):
+        return False
     return (
         _path_ext(rel_path) in RESULT_EXTENSIONS
         and bool(_ancestor_dir_names(rel_path) & RESULT_DIRS)
-        and not is_figure_path(rel_path)
-        and not is_dataset_path(rel_path)
+        and not is_figure_path(rel_path, ignore=ignore)
+        and not is_dataset_path(rel_path, ignore=ignore)
     )
 
 
-def is_presentation_path(rel_path: str) -> bool:
+def is_presentation_path(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> bool:
     """Whether a repo-relative path looks like an auto-detectable presentation.
 
     Either a slide-deck file (PDF/PPTX/KEY) under a ``slides``/``presentations``
     directory, or a file with a presentation-like name (e.g. ``slides.pdf``,
     ``presentation.pdf``) anywhere. Figures are excluded.
     """
-    if is_figure_path(rel_path):
+    if ignore and _is_excluded_from_kind(rel_path, "presentation", ignore):
+        return False
+    if is_figure_path(rel_path, ignore=ignore):
         return False
     name = rel_path.rsplit("/", 1)[-1].lower()
     if name in PRESENTATION_NAMES:
@@ -2040,7 +2092,9 @@ PUBLICATION_NAMES = {
 }
 
 
-def is_publication_path(rel_path: str) -> bool:
+def is_publication_path(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> bool:
     """Whether a repo-relative path looks like an auto-detectable publication.
 
     Either a document (PDF/TeX/DOCX) under a ``paper``/``publication``/
@@ -2048,7 +2102,11 @@ def is_publication_path(rel_path: str) -> bool:
     ``manuscript.pdf``, ``main.tex``) anywhere. Figures and presentations are
     excluded.
     """
-    if is_figure_path(rel_path) or is_presentation_path(rel_path):
+    if ignore and _is_excluded_from_kind(rel_path, "publication", ignore):
+        return False
+    if is_figure_path(rel_path, ignore=ignore) or is_presentation_path(
+        rel_path, ignore=ignore
+    ):
         return False
     name = rel_path.rsplit("/", 1)[-1].lower()
     if name in PUBLICATION_NAMES:
@@ -2058,19 +2116,21 @@ def is_publication_path(rel_path: str) -> bool:
     )
 
 
-def detect_artifact_kind(rel_path: str) -> str | None:
+def detect_artifact_kind(
+    rel_path: str, *, ignore: dict[str, dict] | None = None
+) -> str | None:
     """Infer an artifact's release kind from its repo-relative path.
 
     Returns one of ``"figure"``, ``"presentation"``, ``"publication"``, or
     ``"dataset"``, or ``None`` if the path doesn't look like any of these.
     """
-    if is_figure_path(rel_path):
+    if is_figure_path(rel_path, ignore=ignore):
         return "figure"
-    if is_presentation_path(rel_path):
+    if is_presentation_path(rel_path, ignore=ignore):
         return "presentation"
-    if is_publication_path(rel_path):
+    if is_publication_path(rel_path, ignore=ignore):
         return "publication"
-    if is_dataset_path(rel_path):
+    if is_dataset_path(rel_path, ignore=ignore):
         return "dataset"
     return None
 
@@ -2112,6 +2172,7 @@ def _collapse_dataset_folders(paths: list[str]) -> list[str]:
 def detect_figures(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
+    ignore: dict[str, dict] | None = None,
 ) -> list[str]:
     """Auto-detected figure paths among ``candidate_paths``.
 
@@ -2125,7 +2186,7 @@ def detect_figures(
             for p in candidate_paths
             if not _is_hidden_path(p)
             and not _is_under_any_dir(p, reserved)
-            and is_figure_path(p)
+            and is_figure_path(p, ignore=ignore)
         }
     )
 
@@ -2134,6 +2195,7 @@ def detect_datasets(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
     figure_paths: list[str] | tuple[str, ...] = (),
+    ignore: dict[str, dict] | None = None,
 ) -> list[str]:
     """Auto-detected dataset paths among ``candidate_paths``.
 
@@ -2148,7 +2210,7 @@ def detect_datasets(
         if not _is_hidden_path(p)
         and not _is_under_any_dir(p, reserved)
         and p not in figset
-        and is_dataset_path(p)
+        and is_dataset_path(p, ignore=ignore)
     }
     return _collapse_dataset_folders(sorted(files))
 
@@ -2156,6 +2218,7 @@ def detect_datasets(
 def detect_results(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
+    ignore: dict[str, dict] | None = None,
 ) -> list[str]:
     """Auto-detected result paths among ``candidate_paths``.
 
@@ -2169,7 +2232,7 @@ def detect_results(
             for p in candidate_paths
             if not _is_hidden_path(p)
             and not _is_under_any_dir(p, reserved)
-            and is_result_path(p)
+            and is_result_path(p, ignore=ignore)
         }
     )
 
@@ -2177,6 +2240,7 @@ def detect_results(
 def detect_presentations(
     candidate_paths: list[str],
     reserved_paths: list[str] | tuple[str, ...] = (),
+    ignore: dict[str, dict] | None = None,
 ) -> list[str]:
     """Auto-detected presentation paths among ``candidate_paths``."""
     reserved = list(reserved_paths)
@@ -2186,7 +2250,7 @@ def detect_presentations(
             for p in candidate_paths
             if not _is_hidden_path(p)
             and not _is_under_any_dir(p, reserved)
-            and is_presentation_path(p)
+            and is_presentation_path(p, ignore=ignore)
         }
     )
 
@@ -2276,18 +2340,28 @@ def detect_project_artifacts(
 
     if ck_info is None:
         ck_info = calkit.load_calkit_info(wdir=wdir)
+    ignore = load_detection_ignore(wdir=wdir)
     reserved = _reserved_artifact_paths(wdir=wdir, ck_info=ck_info)
     candidates = list(
         dict.fromkeys(
             [*list_repo_files(wdir=wdir), *list_dvc_tracked_files(wdir=wdir)]
         )
     )
-    figures = detect_figures(candidates, reserved_paths=reserved)
-    datasets = detect_datasets(
-        candidates, reserved_paths=reserved, figure_paths=figures
+    figures = detect_figures(
+        candidates, reserved_paths=reserved, ignore=ignore
     )
-    results = detect_results(candidates, reserved_paths=reserved)
-    presentations = detect_presentations(candidates, reserved_paths=reserved)
+    datasets = detect_datasets(
+        candidates,
+        reserved_paths=reserved,
+        figure_paths=figures,
+        ignore=ignore,
+    )
+    results = detect_results(
+        candidates, reserved_paths=reserved, ignore=ignore
+    )
+    presentations = detect_presentations(
+        candidates, reserved_paths=reserved, ignore=ignore
+    )
     return {
         "figures": figures,
         "datasets": datasets,

--- a/calkit/tests/test_detect.py
+++ b/calkit/tests/test_detect.py
@@ -1311,31 +1311,52 @@ def test_detect_project_artifacts_includes_results_and_presentations(tmp_dir):
     assert "slides/deck.pdf" in out["presentations"]
 
 
-def test_detection_ignore_json(tmp_dir):
-    """``.calkit/ignore.json`` excludes paths from selected artifact kinds."""
+def test_detection_ignore(tmp_dir):
+    """``.calkit/ignore`` excludes paths from all artifact kinds."""
     from calkit.detect import (
+        _load_ignore_spec,
         detect_artifact_kind,
-        detect_datasets,
         detect_figures,
-        load_detection_ignore,
     )
 
-    path = "paper/figs/report.pdf"
-    ignore = {path: {"not": ["figure"]}}
-    assert detect_artifact_kind(path) == "figure"
-    assert detect_artifact_kind(path, ignore=ignore) == "publication"
-    assert path not in detect_figures([path], ignore=ignore)
-    # Excluding one kind does not block other kinds for the same path.
-    assert "data/raw.csv" in detect_datasets(["data/raw.csv"], ignore=ignore)
-    assert "data/raw.csv" not in detect_datasets(
-        ["data/raw.csv"], ignore={"data/raw.csv": {"not": ["dataset"]}}
-    )
-    # No ignore file -> unchanged detection.
-    assert load_detection_ignore() == {}
+    # (e) No ignore file -> unchanged detection.
+    assert _load_ignore_spec() is None
     assert detect_figures(["figures/a.png"]) == ["figures/a.png"]
-    # Malformed JSON -> clear error.
-    os.makedirs(".calkit")
-    with open(".calkit/ignore.json", "w") as f:
-        f.write("{not valid json")
-    with pytest.raises(ValueError, match="Invalid JSON"):
-        load_detection_ignore()
+
+    os.makedirs(".calkit", exist_ok=True)
+    with open(".calkit/ignore", "w") as f:
+        f.write(
+            "\n".join(
+                [
+                    "# this is a comment",
+                    "",
+                    "paper/figs/report.pdf",
+                    "*.ipynb",
+                    "*.csv",
+                    "notebooks/scratch/",
+                ]
+            )
+        )
+
+    ignore = _load_ignore_spec()
+
+    # (a) a path listed in .calkit/ignore is not detected as ANY artifact type
+    path = "paper/figs/report.pdf"
+    assert detect_artifact_kind(path) == "figure"
+    assert detect_artifact_kind(path, ignore=ignore) is None
+    assert path not in detect_figures([path], ignore=ignore)
+
+    # (b) comments and blank lines are ignored (implied by parsing succeeding)
+    assert ignore is not None
+    assert not ignore.match_file("# this is a comment")
+
+    # (c) a glob pattern excludes matching files
+    globbed = "data/raw.csv"
+    assert detect_artifact_kind(globbed) == "dataset"
+    assert detect_artifact_kind(globbed, ignore=ignore) is None
+    assert ignore.match_file("analysis.ipynb") is True
+
+    # (d) a directory pattern excludes files under it
+    in_dir = "notebooks/scratch/data/raw.parquet"
+    assert detect_artifact_kind(in_dir) == "dataset"
+    assert detect_artifact_kind(in_dir, ignore=ignore) is None

--- a/calkit/tests/test_detect.py
+++ b/calkit/tests/test_detect.py
@@ -1309,3 +1309,33 @@ def test_detect_project_artifacts_includes_results_and_presentations(tmp_dir):
     out = calkit.detect.detect_project_artifacts(ck_info={})
     assert "results/metrics.json" in out["results"]
     assert "slides/deck.pdf" in out["presentations"]
+
+
+def test_detection_ignore_json(tmp_dir):
+    """``.calkit/ignore.json`` excludes paths from selected artifact kinds."""
+    from calkit.detect import (
+        detect_artifact_kind,
+        detect_datasets,
+        detect_figures,
+        load_detection_ignore,
+    )
+
+    path = "paper/figs/report.pdf"
+    ignore = {path: {"not": ["figure"]}}
+    assert detect_artifact_kind(path) == "figure"
+    assert detect_artifact_kind(path, ignore=ignore) == "publication"
+    assert path not in detect_figures([path], ignore=ignore)
+    # Excluding one kind does not block other kinds for the same path.
+    assert "data/raw.csv" in detect_datasets(["data/raw.csv"], ignore=ignore)
+    assert "data/raw.csv" not in detect_datasets(
+        ["data/raw.csv"], ignore={"data/raw.csv": {"not": ["dataset"]}}
+    )
+    # No ignore file -> unchanged detection.
+    assert load_detection_ignore() == {}
+    assert detect_figures(["figures/a.png"]) == ["figures/a.png"]
+    # Malformed JSON -> clear error.
+    os.makedirs(".calkit")
+    with open(".calkit/ignore.json", "w") as f:
+        f.write("{not valid json")
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_detection_ignore()

--- a/calkit/tests/test_detect.py
+++ b/calkit/tests/test_detect.py
@@ -1312,15 +1312,14 @@ def test_detect_project_artifacts_includes_results_and_presentations(tmp_dir):
 
 
 def test_detection_ignore(tmp_dir):
-    """``.calkit/ignore`` excludes paths from all artifact kinds."""
     from calkit.detect import (
-        _load_ignore_spec,
         detect_artifact_kind,
         detect_figures,
+        load_detection_ignore,
     )
 
     # (e) No ignore file -> unchanged detection.
-    assert _load_ignore_spec() is None
+    assert load_detection_ignore() is None
     assert detect_figures(["figures/a.png"]) == ["figures/a.png"]
 
     os.makedirs(".calkit", exist_ok=True)
@@ -1338,7 +1337,7 @@ def test_detection_ignore(tmp_dir):
             )
         )
 
-    ignore = _load_ignore_spec()
+    ignore = load_detection_ignore()
 
     # (a) a path listed in .calkit/ignore is not detected as ANY artifact type
     path = "paper/figs/report.pdf"

--- a/calkit/tests/test_detect.py
+++ b/calkit/tests/test_detect.py
@@ -1321,7 +1321,6 @@ def test_detection_ignore(tmp_dir):
     # (e) No ignore file -> unchanged detection.
     assert load_detection_ignore() is None
     assert detect_figures(["figures/a.png"]) == ["figures/a.png"]
-
     os.makedirs(".calkit", exist_ok=True)
     with open(".calkit/ignore", "w") as f:
         f.write(
@@ -1336,25 +1335,20 @@ def test_detection_ignore(tmp_dir):
                 ]
             )
         )
-
     ignore = load_detection_ignore()
-
     # (a) a path listed in .calkit/ignore is not detected as ANY artifact type
     path = "paper/figs/report.pdf"
     assert detect_artifact_kind(path) == "figure"
     assert detect_artifact_kind(path, ignore=ignore) is None
     assert path not in detect_figures([path], ignore=ignore)
-
     # (b) comments and blank lines are ignored (implied by parsing succeeding)
     assert ignore is not None
     assert not ignore.match_file("# this is a comment")
-
     # (c) a glob pattern excludes matching files
     globbed = "data/raw.csv"
     assert detect_artifact_kind(globbed) == "dataset"
     assert detect_artifact_kind(globbed, ignore=ignore) is None
     assert ignore.match_file("analysis.ipynb") is True
-
     # (d) a directory pattern excludes files under it
     in_dir = "notebooks/scratch/data/raw.parquet"
     assert detect_artifact_kind(in_dir) == "dataset"


### PR DESCRIPTION
Closes #947

## What changed
Adds support for a `.calkit/ignore` file (gitignore-style) that lists paths which
should not be detected as artifacts. During artifact auto-detection, any path
matching a line in `.calkit/ignore` is skipped for all artifact types.

Format (one path or pattern per line, gitignore syntax):

    # example notebook, not a pipeline output
    notebooks/scratch.ipynb
    data/tmp/
    *.bak

Glob and directory patterns are supported. Lines starting with `#` are comments for
human explanation and are not parsed. Blank lines are ignored.

## Why
With auto-detection of figures/datasets, irrelevant files (e.g. a scratch notebook or
a stray image that isn't a real pipeline output) can be flagged as artifacts without
provenance. This gives users a simple, familiar way to mark those paths as
"not an artifact" so they're excluded from detection.

## Behavior
- A path matching a line in `.calkit/ignore` is excluded from all artifact type
  detection (figure, dataset, publication, etc.).
- No `.calkit/ignore` present → detection is unchanged.
- Comments (`#`) let users record why a file doesn't need to be reproducible, kept
  inline in the file rather than as a separate schema.

## Design note
This replaces the earlier `.calkit/ignore.json` per-type schema, per discussion with
@petebachant on this PR. A plain gitignore-ish file matches the `.gitignore` /
`.dvcignore` conventions already in the toolchain (same syntax, glob/directory
patterns for free) and covers the actual use case — a blanket "not an artifact" — more
simply than the per-type JSON. If richer structure is ever needed, the file can be
auto-reformatted later since it lives inside the private `.calkit/` directory.

## Testing
- Reworked `test_detection_ignore` in `calkit/tests/test_detect.py` to cover the plain
  file: listed paths excluded from all types, `#` comments and blank lines ignored,
  glob patterns (`*.ipynb`), directory patterns, and the no-file case. The full
  `test_detect.py` suite (42 tests) passes locally.
- `pre-commit` (ruff, ruff-format, prettier, etc.) passes on the changed files.
