### PR TITLE
Add calkit run instructions to latex codespaces tutorial

### DIFF
--- a/docs/tutorials/latex-codespaces.md
+++ b/docs/tutorials/latex-codespaces.md
@@ -116,6 +116,7 @@ Note that the play button will run build just the paper stage.
 It is also possible to have the play button run the entire pipeline
 (like calling `calkit run` from a terminal)
 by editing the `.devcontainer/devcontainer.json`:
+
 ```json
 {
   "image": "ghcr.io/calkit/devcontainer:latest",
@@ -136,6 +137,7 @@ by editing the `.devcontainer/devcontainer.json`:
   },
 }
 ```
+
 This way, we can add more stages later, e.g., for creating figures,
 or even another LaTeX document,
 and everything will be kept up-to-date as needed.

--- a/docs/tutorials/latex-codespaces.md
+++ b/docs/tutorials/latex-codespaces.md
@@ -116,6 +116,7 @@ Note that the play button will run build just the paper stage.
 It is also possible to have the play button run the entire pipeline
 (like calling `calkit run` from a terminal)
 by editing the `.devcontainer/devcontainer.json`:
+```json
 {
   "image": "ghcr.io/calkit/devcontainer:latest",
   "customizations": {

--- a/docs/tutorials/latex-codespaces.md
+++ b/docs/tutorials/latex-codespaces.md
@@ -112,10 +112,31 @@ which will refresh on each build.
 
 ![The editor with buttons.](img/latex-codespaces/editor-split.png)
 
-Note that the play button will run the entire pipeline
-(like calling `calkit run` from a terminal,)
-not just the paper build stage,
-so we can add more stages later, e.g., for creating figures,
+Note that the play button will run build just the paper stage.
+It is also possible to have the play button run the entire pipeline
+(like calling `calkit run` from a terminal)
+by editing the `.devcontainer/devcontainer.conf`:
+```yaml
+{
+  "image": "ghcr.io/calkit/devcontainer:latest",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        ...
+        # Add these lines
+        "latex-workshop.latex.external.build.command": "calkit",
+        "latex-workshop.latex.external.build.args": [
+            "run"
+        ],
+        # Comment-out or remove these lines
+        # "latex-workshop.docker.image.latex": "texlive/texlive:latest-full",
+        # "latex-workshop.docker.enabled": true,
+      }
+    }
+  },
+}
+```
+This we, we can add more stages later, e.g., for creating figures,
 or even another LaTeX document,
 and everything will be kept up-to-date as needed.
 This is a major difference between this workflow and that of a typical

--- a/docs/tutorials/latex-codespaces.md
+++ b/docs/tutorials/latex-codespaces.md
@@ -115,8 +115,7 @@ which will refresh on each build.
 Note that the play button will run build just the paper stage.
 It is also possible to have the play button run the entire pipeline
 (like calling `calkit run` from a terminal)
-by editing the `.devcontainer/devcontainer.conf`:
-```yaml
+by editing the `.devcontainer/devcontainer.json`:
 {
   "image": "ghcr.io/calkit/devcontainer:latest",
   "customizations": {

--- a/docs/tutorials/latex-codespaces.md
+++ b/docs/tutorials/latex-codespaces.md
@@ -135,7 +135,7 @@ by editing the `.devcontainer/devcontainer.json`:
   },
 }
 ```
-This we, we can add more stages later, e.g., for creating figures,
+This way, we can add more stages later, e.g., for creating figures,
 or even another LaTeX document,
 and everything will be kept up-to-date as needed.
 This is a major difference between this workflow and that of a typical


### PR DESCRIPTION
The [GitHub Codespaces tutorial](https://github.com/calkit/calkit/blob/e4191447a4fefef3ad1a8a4a6ccfe80b956a8046/docs/tutorials/latex-codespaces.md?plain=1#L115-L117) currently state "Note that the play button will run the entire pipeline (like calling `calkit run` from a terminal,) not just the paper build stage". However, it seems that #376 planned to include this functionality, but #595 instead has LaTeX-Workshop run in a `texlive/texlive` Docker container without running `calkit`.

This PR clarifies the default behavior (just build the paper stage) while also providing instructions for modifying the devcontainer to run calkit, as described in #376.