### PR TITLE
Normalize trailing slash/whitespace in overleaf sync path (fixes #985)

### DIFF
--- a/calkit/cli/overleaf.py
+++ b/calkit/cli/overleaf.py
@@ -437,7 +437,12 @@ def sync(
         raise_error("No Overleaf sync info found")
     overleaf_sync_dirs = list(overleaf_info.keys())
     if paths is not None:
-        paths = [os.path.dirname(p) if os.path.isfile(p) else p for p in paths]
+        paths = [
+            (os.path.dirname(p) if os.path.isfile(p) else p)
+            .strip()
+            .rstrip("/\\")
+            for p in paths
+        ]
         for path in paths:
             if path not in overleaf_sync_dirs:
                 raise_error(f"Path '{path}' is not synced with Overleaf")
@@ -611,7 +616,12 @@ def get_status(
         raise_error("No Overleaf sync info found")
     overleaf_sync_dirs = list(overleaf_info.keys())
     if paths is not None:
-        paths = [os.path.dirname(p) if os.path.isfile(p) else p for p in paths]
+        paths = [
+            (os.path.dirname(p) if os.path.isfile(p) else p)
+            .strip()
+            .rstrip("/\\")
+            for p in paths
+        ]
         for path in paths:
             if path not in overleaf_sync_dirs:
                 raise_error(f"Path '{path}' is not synced with Overleaf")

--- a/calkit/tests/cli/test_overleaf.py
+++ b/calkit/tests/cli/test_overleaf.py
@@ -362,3 +362,50 @@ def test_extract_title_from_tex(tmp_dir):
         f.write(tex)
     title = _extract_title_from_tex("test.tex")
     assert title == "My Cool Paper"
+
+
+def test_overleaf_sync_trailing_slash_or_space(tmp_dir):
+    pid = str(uuid.uuid4())
+    ol_repo = _make_temp_overleaf_project(pid)
+    ol_repo.git.config(["receive.denyCurrentBranch", "ignore"])
+    subprocess.run(["calkit", "init"], check=True)
+    repo = git.Repo()
+    tmp_remote = (
+        Path(tempfile.gettempdir()) / "overleaf-sync-remotes" / pid
+    ).as_posix()
+    os.makedirs(tmp_remote, exist_ok=True)
+    remote_repo = git.Repo.init(path=tmp_remote, bare=True)
+    remote_repo.git.config(["receive.denyCurrentBranch", "ignore"])
+    repo.git.config(["push.autoSetupRemote", "true"])
+    repo.git.remote(["add", "origin", tmp_remote])
+    ol_url = calkit.overleaf.get_git_remote_url(pid, "no token")
+    assert os.environ["CALKIT_ENV"] == "test"
+    assert os.environ["CALKIT_TEST_OVERLEAF_TOKEN"] == "none"
+    config = calkit.config.read()
+    assert config.overleaf_token == "none"
+    subprocess.run(
+        [
+            "calkit",
+            "overleaf",
+            "import",
+            ol_url,
+            "pubs/applied-ocean-research",
+            "--title",
+            "Test Pub",
+        ],
+        check=True,
+    )
+    # Try syncing with a trailing slash
+    res = subprocess.run(
+        ["calkit", "overleaf", "sync", "pubs/applied-ocean-research/"],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"Trailing slash sync failed: {res.stderr}"
+    # Try syncing with a trailing space
+    res2 = subprocess.run(
+        ["calkit", "overleaf", "sync", "pubs/applied-ocean-research "],
+        capture_output=True,
+        text=True,
+    )
+    assert res2.returncode == 0, f"Trailing space sync failed: {res2.stderr}"


### PR DESCRIPTION
## Summary

Fixes #985.

`calkit overleaf sync pubs/applied-ocean-research` works, but the same path with a trailing slash — `pubs/applied-ocean-research/`, which is what shell tab-completion inserts — errored with "no Overleaf doc found." The trailing separator was carried into the doc lookup, so it failed to match the stored key `pubs/applied-ocean-research`.

## Reproduction
calkit overleaf sync pubs/applied-ocean-research     # works
calkit overleaf sync pubs/applied-ocean-research/    # errors: no doc found

## Change

Normalize the input path before the lookup — strip trailing path separators (`/` and `\`) and surrounding whitespace — applied at both the `sync` and `get_status` entry points in `calkit/cli/overleaf.py`. Stored names are untouched; only the user-supplied input is normalized.

The issue title says "trailing spaces" while the body reports a trailing slash, so the fix handles both.

## Tests

Added a regression test that imports and syncs a project using the trailing-slash path form and confirms it resolves correctly (previously errored). Existing overleaf tests unaffected.