### PR TITLE
Add gitignore exception for .dvc pointer files when adding to DVC (fixes #964)

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -786,6 +786,8 @@ def add(
         elif to == "git":
             subprocess.call(["git", "add"] + paths)
         elif to == "dvc":
+            for path in paths:
+                calkit.git.ensure_dvc_pointer_is_not_ignored(repo, path)
             calkit.dvc.run_dvc_command(["add"] + paths)
         elif to == "dvc-zip":
             for path in paths:
@@ -899,6 +901,7 @@ def add(
                         f"Adding {path} to DVC since it's already tracked "
                         "with DVC"
                     )
+                    calkit.git.ensure_dvc_pointer_is_not_ignored(repo, path)
                     calkit.dvc.run_dvc_command(["add", path])
             elif posix_path in pipeline_output_storage:
                 # Respect storage explicitly set in the pipeline definition
@@ -943,6 +946,7 @@ def add(
                     typer.echo(f"Would add {path} to DVC (per extension)")
                 else:
                     typer.echo(f"Adding {path} to DVC per its extension")
+                    calkit.git.ensure_dvc_pointer_is_not_ignored(repo, path)
                     calkit.dvc.run_dvc_command(["add", path])
             elif calkit.dvc.zip.is_zip_candidate(path):
                 if dry_run:
@@ -963,6 +967,7 @@ def add(
                     typer.echo(
                         f"Adding {path} to DVC since it's greater than 1 MB"
                     )
+                    calkit.git.ensure_dvc_pointer_is_not_ignored(repo, path)
                     calkit.dvc.run_dvc_command(["add", path])
             else:
                 if dry_run:
@@ -3218,6 +3223,14 @@ def call_dvc(
     and DVC is not installed.
     """
     result = calkit.dvc.run_dvc_command(sys.argv[2:])
+    if result != 0 and len(sys.argv) > 2 and sys.argv[2] == "add":
+        typer.secho(
+            "Hint: If DVC failed because a .dvc pointer file is git-ignored, "
+            "use `calkit add --to=dvc <path>` instead so Calkit can "
+            "automatically manage the gitignore exception.",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
     sys.exit(result)
 
 

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 from os import PathLike
 from pathlib import Path
 
@@ -351,15 +350,8 @@ def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
     """
     path = path.replace("\\", "/").rstrip("/")
     pointer = path + ".dvc"
-    # git check-ignore exits 0 if IGNORED, 1 if NOT ignored, 2 on error.
-    result = subprocess.run(
-        ["git", "check-ignore", pointer],
-        cwd=repo.working_dir,
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return  # not ignored (1) or error (2) -> nothing to do
+    if pointer not in repo.ignored(pointer):
+        return
     pointer_dir = os.path.dirname(pointer)
     gitignore_path = os.path.join(repo.working_dir, pointer_dir, ".gitignore")
     exception = "!*.dvc"
@@ -368,7 +360,7 @@ def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
         with open(gitignore_path, "r", encoding="utf-8") as f:
             existing_lines = f.read().splitlines()
     if exception in existing_lines:
-        return  # already present
+        return  # Already present
     os.makedirs(os.path.dirname(gitignore_path), exist_ok=True)
     with open(gitignore_path, "a", encoding="utf-8") as f:
         if existing_lines and existing_lines[-1] != "":

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -351,7 +351,6 @@ def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
     """
     path = path.replace("\\", "/").rstrip("/")
     pointer = path + ".dvc"
-
     # git check-ignore exits 0 if IGNORED, 1 if NOT ignored, 2 on error.
     result = subprocess.run(
         ["git", "check-ignore", pointer],
@@ -361,19 +360,15 @@ def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
     )
     if result.returncode != 0:
         return  # not ignored (1) or error (2) -> nothing to do
-
     pointer_dir = os.path.dirname(pointer)
     gitignore_path = os.path.join(repo.working_dir, pointer_dir, ".gitignore")
     exception = "!*.dvc"
-
     existing_lines = []
     if os.path.isfile(gitignore_path):
         with open(gitignore_path, "r", encoding="utf-8") as f:
             existing_lines = f.read().splitlines()
-
     if exception in existing_lines:
         return  # already present
-
     os.makedirs(os.path.dirname(gitignore_path), exist_ok=True)
     with open(gitignore_path, "a", encoding="utf-8") as f:
         if existing_lines and existing_lines[-1] != "":

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import subprocess
 from os import PathLike
 from pathlib import Path
 
@@ -337,3 +338,44 @@ def ensure_path_is_not_ignored(
     if target_repo.ignored(target_path) and _depth < 10:
         ensure_path_is_not_ignored(target_repo, target_path, _depth + 1)
     return True
+
+
+def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
+    """Ensure the .dvc pointer for ``path`` will not be Git-ignored.
+
+    A broad pattern in a ``.gitignore`` (e.g. ``*.pdf*``) can also match the
+    ``<path>.dvc`` pointer DVC commits to Git, causing ``dvc add`` to fail with
+    "bad DVC file name ... is git-ignored". This appends a ``!*.dvc`` negation
+    to the ``.gitignore`` in the pointer's own directory (which wins under Git
+    precedence) so pointers stay tracked. Idempotent.
+    """
+    path = path.replace("\\", "/").rstrip("/")
+    pointer = path + ".dvc"
+
+    # git check-ignore exits 0 if IGNORED, 1 if NOT ignored, 2 on error.
+    result = subprocess.run(
+        ["git", "check-ignore", pointer],
+        cwd=repo.working_dir,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return  # not ignored (1) or error (2) -> nothing to do
+
+    pointer_dir = os.path.dirname(pointer)
+    gitignore_path = os.path.join(repo.working_dir, pointer_dir, ".gitignore")
+    exception = "!*.dvc"
+
+    existing_lines = []
+    if os.path.isfile(gitignore_path):
+        with open(gitignore_path, "r", encoding="utf-8") as f:
+            existing_lines = f.read().splitlines()
+
+    if exception in existing_lines:
+        return  # already present
+
+    os.makedirs(os.path.dirname(gitignore_path), exist_ok=True)
+    with open(gitignore_path, "a", encoding="utf-8") as f:
+        if existing_lines and existing_lines[-1] != "":
+            f.write("\n")
+        f.write(exception + "\n")

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -1891,11 +1891,9 @@ def test_call_dvc_passthrough_hint(tmp_dir):
     os.makedirs("data")
     with open("data/.gitignore", "w") as f:
         f.write("*.pdf*\n")
-
     pdf_path = "data/doc.pdf"
     with open(pdf_path, "w") as f:
         f.write("doc")
-
     # Run the passthrough dvc add which will fail because it's ignored
     res = subprocess.run(
         ["calkit", "dvc", "add", pdf_path], capture_output=True, text=True

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -1845,25 +1845,19 @@ def test_add_dvc_pointer_unignored(tmp_dir):
     os.makedirs("pubs/defense/ppt")
     with open("pubs/defense/ppt/.gitignore", "w") as f:
         f.write("*.pdf*\n")
-
     pdf_path = "pubs/defense/ppt/McCabe.pdf"
     with open(pdf_path, "w") as f:
         f.write("dummy pdf content")
-
     subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
-
     # Assert pointer exists
     dvc_file = f"{pdf_path}.dvc"
     assert os.path.exists(dvc_file)
-
     # Assert pointer is NOT ignored (should return 1)
     res = subprocess.run(["git", "check-ignore", "-q", dvc_file])
     assert res.returncode == 1
-
     # Assert data file IS still ignored
     res_data = subprocess.run(["git", "check-ignore", "-q", pdf_path])
     assert res_data.returncode == 0
-
     # Assert it was staged
     staged = calkit.git.get_staged_files()
     assert dvc_file in staged
@@ -1876,22 +1870,16 @@ def test_add_dvc_pointer_unignored_idempotent(tmp_dir):
     os.makedirs("data")
     with open("data/.gitignore", "w") as f:
         f.write("*.pdf*\n")
-
     pdf_path = "data/doc.pdf"
     with open(pdf_path, "w") as f:
         f.write("doc")
-
     subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
-
     with open("data/.gitignore") as f:
         content1 = f.read()
-
     # Second add should not duplicate
     subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
-
     with open("data/.gitignore") as f:
         content2 = f.read()
-
     assert content1 == content2
     assert content1.count("!*.dvc") == 1
 

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -1836,3 +1836,84 @@ def test_run_downstream_does_not_submit_unrelated_sweep(tmp_dir):
     assert os.path.exists("other.txt")
     assert not os.path.exists("out-1.txt")
     assert not os.path.exists("out-2.txt")
+
+
+def test_add_dvc_pointer_unignored(tmp_dir):
+    """Test that calkit add --to=dvc ensures the .dvc pointer is unignored."""
+    subprocess.check_call(["git", "init"])
+    subprocess.check_call(["calkit", "init"])
+    os.makedirs("pubs/defense/ppt")
+    with open("pubs/defense/ppt/.gitignore", "w") as f:
+        f.write("*.pdf*\n")
+
+    pdf_path = "pubs/defense/ppt/McCabe.pdf"
+    with open(pdf_path, "w") as f:
+        f.write("dummy pdf content")
+
+    subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
+
+    # Assert pointer exists
+    dvc_file = f"{pdf_path}.dvc"
+    assert os.path.exists(dvc_file)
+
+    # Assert pointer is NOT ignored (should return 1)
+    res = subprocess.run(["git", "check-ignore", "-q", dvc_file])
+    assert res.returncode == 1
+
+    # Assert data file IS still ignored
+    res_data = subprocess.run(["git", "check-ignore", "-q", pdf_path])
+    assert res_data.returncode == 0
+
+    # Assert it was staged
+    staged = calkit.git.get_staged_files()
+    assert dvc_file in staged
+
+
+def test_add_dvc_pointer_unignored_idempotent(tmp_dir):
+    """Test that the unignore logic does not duplicate lines."""
+    subprocess.check_call(["git", "init"])
+    subprocess.check_call(["calkit", "init"])
+    os.makedirs("data")
+    with open("data/.gitignore", "w") as f:
+        f.write("*.pdf*\n")
+
+    pdf_path = "data/doc.pdf"
+    with open(pdf_path, "w") as f:
+        f.write("doc")
+
+    subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
+
+    with open("data/.gitignore") as f:
+        content1 = f.read()
+
+    # Second add should not duplicate
+    subprocess.check_call(["calkit", "add", "--to=dvc", pdf_path])
+
+    with open("data/.gitignore") as f:
+        content2 = f.read()
+
+    assert content1 == content2
+    assert content1.count("!*.dvc") == 1
+
+
+def test_call_dvc_passthrough_hint(tmp_dir):
+    """Test that calkit dvc add prints a hint if .dvc is ignored."""
+    subprocess.check_call(["git", "init"])
+    subprocess.check_call(["calkit", "init"])
+    os.makedirs("data")
+    with open("data/.gitignore", "w") as f:
+        f.write("*.pdf*\n")
+
+    pdf_path = "data/doc.pdf"
+    with open(pdf_path, "w") as f:
+        f.write("doc")
+
+    # Run the passthrough dvc add which will fail because it's ignored
+    res = subprocess.run(
+        ["calkit", "dvc", "add", pdf_path], capture_output=True, text=True
+    )
+    assert res.returncode != 0
+    assert (
+        "Hint: If DVC failed because a .dvc pointer file is git-ignored"
+        in res.stderr
+    )


### PR DESCRIPTION
Previously the only workaround was manually adding negations like `!*.pdf.dvc` and `!*.pptx.dvc` to `.gitignore`.

## Fix

Adds `calkit.git.ensure_dvc_pointer_is_not_ignored(repo, path)`, called on the wrapped `calkit add --to=dvc` path (and the auto-route-to-DVC path) before running `dvc add`. It:

- checks whether `<path>.dvc` is currently ignored via `git check-ignore`, acting only when it actually is (exit code 0);
- if so, appends a `!*.dvc` exception to the `.gitignore` in the pointer's own directory, which takes precedence over a broader pattern in the same or a shallower `.gitignore`;
- is idempotent — it won't duplicate the `!*.dvc` line on repeat adds;
- normalizes paths to posix so it behaves the same on Windows.

`.dvc` pointer files must stay tracked by Git for DVC versioning to work, so this ensures Calkit's managed gitignores never exclude them.

## Scope

Per the maintainer's note on the issue, this targets the wrapped `calkit add --to=dvc` command. `calkit dvc add` remains a thin passthrough to the DVC CLI and does not go through this logic.

## Tests

- `test_add_dvc_pointer_unignored` — reproduces the issue (a `*.pdf*` pattern in a subdirectory `.gitignore`), then asserts the add succeeds, the `.dvc` pointer is tracked, and the real data file stays ignored.
- `test_add_dvc_pointer_unignored_idempotent` — asserts a second add doesn't duplicate the exception line.
- Existing `test_add` still passes.