### PR TITLE
Do not put release artifact file name in stored path

### DIFF
--- a/calkit/cli/new.py
+++ b/calkit/cli/new.py
@@ -3258,16 +3258,12 @@ def new_release(
         # stored as-is (renamed); folders and whole-project releases are
         # zipped.
         project_name = calkit.detect_project_name(prepend_owner=False)
-        if path == ".":
+        if path == "." or os.path.isdir(path):
             stored_filename = f"{project_name}-{name}.zip"
             is_zip = True
-        elif os.path.isdir(path):
-            folder_name = os.path.basename(os.path.normpath(path))
-            stored_filename = f"{project_name}-{folder_name}-{name}.zip"
-            is_zip = True
         elif os.path.isfile(path):
-            stem, ext = os.path.splitext(os.path.basename(path))
-            stored_filename = f"{project_name}-{stem}-{name}{ext}"
+            _, ext = os.path.splitext(os.path.basename(path))
+            stored_filename = f"{project_name}-{name}{ext}"
             is_zip = False
         else:
             raise_error(f"Release path '{path}' does not exist")

--- a/calkit/tests/cli/test_new.py
+++ b/calkit/tests/cli/test_new.py
@@ -760,7 +760,7 @@ def test_new_nix_env_stages_flake(tmp_dir):
     )
     assert os.path.isfile("flake.nix")
     repo = git.Repo(".")
-    head_files = [item.path for item in repo.head.commit.tree.traverse()]
+    head_files = [item.path for item in repo.head.commit.tree.traverse()]  # type: ignore
     assert "flake.nix" in head_files
     assert "calkit.yaml" in head_files
 
@@ -991,26 +991,26 @@ def test_new_internal_release(tmp_dir):
             "--to",
             "none",
             "--name",
-            "v0",
+            "slides-v0",
             "--desc",
-            "First version sent to Mo for review.",
+            "First version sent for review.",
             "--no-push",
         ]
     )
     ck_info = calkit.load_calkit_info()
-    assert "v0" in ck_info["releases"]
-    release = ck_info["releases"]["v0"]
+    assert "slides-v0" in ck_info["releases"]
+    release = ck_info["releases"]["slides-v0"]
     assert release["internal"] is True
     assert release["kind"] == "presentation"
     assert release["doi"] is None
     assert release["calkit_version"] == calkit.__version__
-    assert release["description"] == "First version sent to Mo for review."
+    assert release["description"] == "First version sent for review."
     assert (
         release["stored_path"]
-        == ".calkit/releases/v0/test-project-slides-v0.pdf"
+        == ".calkit/releases/slides-v0/test-project-slides-v0.pdf"
     )
     assert os.path.isfile(release["stored_path"])
-    assert "v0" in [t.name for t in git.Repo().tags]
+    assert "slides-v0" in [t.name for t in git.Repo().tags]
     # Internal release of a folder: zipped with a self-describing name
     subprocess.check_call(
         [
@@ -1020,14 +1020,15 @@ def test_new_internal_release(tmp_dir):
             "data/raw",
             "--internal",
             "--name",
-            "v1",
+            "raw-data-v1",
             "--no-push",
         ]
     )
-    release = calkit.load_calkit_info()["releases"]["v1"]
+    release = calkit.load_calkit_info()["releases"]["raw-data-v1"]
     assert release["kind"] == "dataset"
     assert (
-        release["stored_path"] == ".calkit/releases/v1/test-project-raw-v1.zip"
+        release["stored_path"]
+        == ".calkit/releases/raw-data-v1/test-project-raw-data-v1.zip"
     )
     assert os.path.isfile(release["stored_path"])
     # Internal release of the whole project: zipped archive
@@ -1068,10 +1069,7 @@ def test_new_internal_release(tmp_dir):
     )
     release = calkit.load_calkit_info()["releases"]["v3"]
     assert release["kind"] == "figure"
-    assert (
-        release["stored_path"]
-        == ".calkit/releases/v3/test-project-plot-v3.png"
-    )
+    assert release["stored_path"] == ".calkit/releases/v3/test-project-v3.png"
     # A path that isn't a defined artifact should fail kind detection
     with open("notes.txt", "w") as f:
         f.write("hello\n")
@@ -1110,10 +1108,7 @@ def test_new_internal_release(tmp_dir):
     )
     release = calkit.load_calkit_info()["releases"]["v5"]
     assert release["kind"] == "dataset"
-    assert (
-        release["stored_path"]
-        == ".calkit/releases/v5/test-project-notes-v5.txt"
-    )
+    assert release["stored_path"] == ".calkit/releases/v5/test-project-v5.txt"
     # Listing releases must not warn about publication status for internal
     # releases, which have no publisher or record ID
     result = subprocess.run(

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -67,9 +67,9 @@ calkit init [OPTIONS]
 
 Options:
 
-| Option          | Type    | Required | Default | Description                                      |
-| --------------- | ------- | -------- | ------- | ------------------------------------------------ |
-| `--force`, `-f` | boolean | no       | False   | Force reinitializing DVC if already initialized. |
+| Option          | Type    | Required | Default | Description                                               |
+| --------------- | ------- | -------- | ------- | --------------------------------------------------------- |
+| `--force`, `-f` | boolean | no       | False   | Re-initialize even if the project is already initialized. |
 
 <a id="top-command-clone"></a>
 


### PR DESCRIPTION
Users should be putting something in the release name to identify which artifact is being released.