### PR TITLE
Skip unrelated subproject checks for single-item runs (fixes #963)

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1688,13 +1688,17 @@ def _concurrent_scheduler_prepass(
 
 
 def _get_subproject_targets_for_run(
-    subproject_path: str, targets: list[str] | None
+    subproject_path: str,
+    targets: list[str] | None,
+    include_dvc_yaml_targets: bool = False,
 ) -> tuple[bool, list[str] | None]:
     """Return whether and which subproject stages a run target selects."""
     if not targets:
         return True, None
     sp = Path(subproject_path).as_posix()
     target_prefixes = {sp, Path(sp).name}
+    if include_dvc_yaml_targets:
+        target_prefixes.add(f"{sp}/dvc.yaml")
     selected_stages = []
     for target in targets:
         target_prefix, separator, stage_name = target.partition(":")
@@ -1965,7 +1969,11 @@ def run(
                 continue
             if single_item:
                 sp_selected, sp_targets = _get_subproject_targets_for_run(
-                    subproject_path=sp, targets=targets
+                    subproject_path=sp,
+                    targets=targets,
+                    include_dvc_yaml_targets=not os.path.isdir(
+                        os.path.join(sp, ".dvc")
+                    ),
                 )
                 if not sp_selected:
                     continue

--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1687,6 +1687,25 @@ def _concurrent_scheduler_prepass(
                 )
 
 
+def _get_subproject_targets_for_run(
+    subproject_path: str, targets: list[str] | None
+) -> tuple[bool, list[str] | None]:
+    """Return whether and which subproject stages a run target selects."""
+    if not targets:
+        return True, None
+    sp = Path(subproject_path).as_posix()
+    target_prefixes = {sp, Path(sp).name}
+    selected_stages = []
+    for target in targets:
+        target_prefix, separator, stage_name = target.partition(":")
+        if target_prefix not in target_prefixes:
+            continue
+        if not separator or not stage_name:
+            return True, None
+        selected_stages.append(stage_name)
+    return bool(selected_stages), selected_stages or None
+
+
 @app.command(name="run")
 def run(
     targets: Annotated[
@@ -1944,6 +1963,14 @@ def run(
             sp = Path(subproject["path"]).as_posix()
             if not os.path.isdir(sp):
                 continue
+            if single_item:
+                sp_selected, sp_targets = _get_subproject_targets_for_run(
+                    subproject_path=sp, targets=targets
+                )
+                if not sp_selected:
+                    continue
+            else:
+                sp_targets = None
             os.chdir(sp)
             try:
                 sp_ck_info = calkit.load_calkit_info()
@@ -1952,7 +1979,7 @@ def run(
                         f"📦 Checking environments for subproject: {sp}"
                     )
                 sp_env_results = calkit.environments.check_all_in_pipeline(
-                    ck_info=sp_ck_info, force=force
+                    ck_info=sp_ck_info, targets=sp_targets, force=force
                 )
                 for env_name, sp_result in sp_env_results.items():
                     if verbose:

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -22,6 +22,7 @@ import calkit.cli.main
 from calkit.cli.core import complete_stage_names
 from calkit.cli.main.core import (
     _get_running_pipeline_status,
+    _get_subproject_targets_for_run,
     _prune_run_logs,
     _run_dvc_repro,
     _stage_run_info_from_log_content,
@@ -43,6 +44,22 @@ skipif_windows_mock_scheduler = pytest.mark.skipif(
     sys.platform == "win32",
     reason="TODO: mock scheduler is not yet Windows-compatible",
 )
+
+
+@pytest.mark.parametrize(
+    ("subproject_path", "targets", "expected"),
+    [
+        ("sub1", None, (True, None)),
+        ("sub1", ["parent-stage"], (False, None)),
+        ("sub1", ["sub1"], (True, None)),
+        ("nested/sub1", ["sub1:build"], (True, ["build"])),
+        ("nested/sub1", ["nested/sub1:build"], (True, ["build"])),
+    ],
+)
+def test_get_subproject_targets_for_run(subproject_path, targets, expected):
+    assert (
+        _get_subproject_targets_for_run(subproject_path, targets) == expected
+    )
 
 
 def _repo_test_file(name: str) -> Path:

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -47,18 +47,48 @@ skipif_windows_mock_scheduler = pytest.mark.skipif(
 
 
 @pytest.mark.parametrize(
-    ("subproject_path", "targets", "expected"),
+    ("subproject_path", "targets", "include_dvc_yaml_targets", "expected"),
     [
-        ("sub1", None, (True, None)),
-        ("sub1", ["parent-stage"], (False, None)),
-        ("sub1", ["sub1"], (True, None)),
-        ("nested/sub1", ["sub1:build"], (True, ["build"])),
-        ("nested/sub1", ["nested/sub1:build"], (True, ["build"])),
+        ("sub1", None, False, (True, None)),
+        ("sub1", ["parent-stage"], False, (False, None)),
+        ("sub1", ["sub1"], False, (True, None)),
+        ("nested/sub1", ["sub1:build"], False, (True, ["build"])),
+        (
+            "nested/sub1",
+            ["nested/sub1:build"],
+            False,
+            (True, ["build"]),
+        ),
+        (
+            "nested/sub1",
+            ["nested/sub1/dvc.yaml"],
+            True,
+            (True, None),
+        ),
+        (
+            "nested/sub1",
+            ["nested/sub1/dvc.yaml:build"],
+            True,
+            (True, ["build"]),
+        ),
+        (
+            "nested/sub1",
+            ["nested/sub1/dvc.yaml:build"],
+            False,
+            (False, None),
+        ),
     ],
 )
-def test_get_subproject_targets_for_run(subproject_path, targets, expected):
+def test_get_subproject_targets_for_run(
+    subproject_path, targets, include_dvc_yaml_targets, expected
+):
     assert (
-        _get_subproject_targets_for_run(subproject_path, targets) == expected
+        _get_subproject_targets_for_run(
+            subproject_path,
+            targets,
+            include_dvc_yaml_targets=include_dvc_yaml_targets,
+        )
+        == expected
     )
 
 

--- a/calkit/tests/cli/main/test_subprojects.py
+++ b/calkit/tests/cli/main/test_subprojects.py
@@ -115,6 +115,52 @@ def test_inline_subproject(tmp_dir):
         assert "v2" in f.read()
 
 
+def test_single_item_skips_unrelated_subproject_preparation(tmp_dir):
+    subprocess.check_call(["calkit", "init"])
+    os.makedirs("sub1")
+    write_ck_info(
+        "sub1/calkit.yaml",
+        {
+            "pipeline": {
+                "stages": {
+                    "subproject-only": make_stage(
+                        'echo "subproject" > subproject.txt'
+                    )
+                }
+            }
+        },
+    )
+    write_ck_info(
+        "calkit.yaml",
+        {
+            "subprojects": [{"path": "sub1"}],
+            "pipeline": {
+                "stages": {
+                    "parent-only": make_stage('echo "parent" > parent.txt')
+                }
+            },
+        },
+    )
+    result = subprocess.run(
+        ["calkit", "run", "--single-item", "parent-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert os.path.isfile("parent.txt")
+    assert "Checking environments for subproject" not in result.stdout
+    selected_subproject = subprocess.run(
+        ["calkit", "run", "--single-item", "sub1:subproject-only"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert os.path.isfile("sub1/subproject.txt")
+    assert "Checking environments for subproject: sub1" in (
+        selected_subproject.stdout
+    )
+
+
 def init_isolated_subproject(path, stages):
     os.makedirs(path, exist_ok=True)
     subprocess.check_call(["git", "init"], cwd=path)

--- a/calkit/tests/cli/main/test_subprojects.py
+++ b/calkit/tests/cli/main/test_subprojects.py
@@ -160,6 +160,7 @@ def test_single_item_skips_unrelated_subproject_preparation(tmp_dir):
         selected_subproject.stdout
     )
 
+    # A DVC-style inline target should still prepare the selected subproject.
     write_ck_info(
         "sub1/calkit.yaml",
         {

--- a/calkit/tests/cli/main/test_subprojects.py
+++ b/calkit/tests/cli/main/test_subprojects.py
@@ -186,7 +186,7 @@ def test_single_item_skips_unrelated_subproject_preparation(tmp_dir):
         text=True,
     )
     with open("sub1/subproject.txt") as f:
-        assert f.read().strip() == "dvc target"
+        assert "dvc target" in f.read()
     assert "Checking environments for subproject: sub1" in (
         selected_inline_dvc_target.stdout
     )

--- a/calkit/tests/cli/main/test_subprojects.py
+++ b/calkit/tests/cli/main/test_subprojects.py
@@ -160,6 +160,36 @@ def test_single_item_skips_unrelated_subproject_preparation(tmp_dir):
         selected_subproject.stdout
     )
 
+    write_ck_info(
+        "sub1/calkit.yaml",
+        {
+            "pipeline": {
+                "stages": {
+                    "subproject-only": make_stage(
+                        'echo "dvc target" > subproject.txt'
+                    )
+                }
+            }
+        },
+    )
+    calkit.pipeline.to_dvc(write=True, manage_gitignore=False)
+    selected_inline_dvc_target = subprocess.run(
+        [
+            "calkit",
+            "run",
+            "--single-item",
+            "sub1/dvc.yaml:subproject-only",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    with open("sub1/subproject.txt") as f:
+        assert f.read().strip() == "dvc target"
+    assert "Checking environments for subproject: sub1" in (
+        selected_inline_dvc_target.stdout
+    )
+
 
 def init_isolated_subproject(path, stages):
     os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
## Summary

- skip environment and notebook preparation for subprojects unrelated to a `--single-item` target
- preserve subproject preparation when the selected target belongs to an inline or isolated subproject
- limit selected subproject environment checks to the requested stage
- add regression coverage for both an unrelated parent stage and a selected subproject stage

## Tests

- `uv run pytest -n 0 -p no:pytest_jupyter.jupyter_server calkit/tests/cli/main/test_core.py::test_get_subproject_targets_for_run calkit/tests/cli/main/test_subprojects.py calkit/tests/test_environments.py calkit/tests/test_pipeline.py::test_translate_run_targets -q`
- `uv run pre-commit run --files calkit/cli/main/core.py calkit/tests/cli/main/test_core.py calkit/tests/cli/main/test_subprojects.py`
- focused regression matrix on Python 3.10, 3.12, and 3.14
- source distribution and wheel build with `uv build`

Fixes #963
