### PR TITLE
Change dvc log level from ERROR to WARNING

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -2218,7 +2218,7 @@ def run(
     file_handler.setFormatter(formatter)
     dvc.log.logger.addHandler(file_handler)
     # Remove newline logging in dvc.repo.reproduce
-    dvc.repo.reproduce.logger.setLevel(logging.ERROR)
+    dvc.repo.reproduce.logger.setLevel(logging.WARNING)
     # Disable other misc DVC output
     dvc.ui.ui.write = lambda *args, **kwargs: None
     # Tell `calkit scheduler batch` to resubmit completed jobs under --force;


### PR DESCRIPTION
Closes #575 in which errors were not logged if `--keep-going` flag was used in the run.