### PR TITLE
Allow stage-scoped system dependencies (#1029)

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1935,7 +1935,9 @@ def run(
     if not quiet:
         calkit.echo("🔗 Checking system-level dependencies")
     try:
-        calkit.check_system_deps(ck_info=ck_info, system_info=system_info)
+        calkit.check_system_deps(
+            ck_info=ck_info, system_info=system_info, targets=targets
+        )
     except Exception as e:
         os.environ.pop("CALKIT_PIPELINE_RUNNING", None)
         raise_error(str(e))

--- a/calkit/core.py
+++ b/calkit/core.py
@@ -445,6 +445,7 @@ def check_system_deps(
     system_info: dict | None = None,
     interactive: bool | None = None,
     use_cache: bool = True,
+    targets: list[str] | None = None,
 ) -> None:
     """Check that the dependencies declared in a project's ``calkit.yaml`` file
     exist.
@@ -458,6 +459,22 @@ def check_system_deps(
     if ck_info is None:
         ck_info = load_calkit_info(wdir=wdir)
     deps = list(ck_info.get("dependencies", []))
+
+    stages = ck_info.get("pipeline", {}).get("stages", {})
+    if targets:
+        # Split targets by "@" to handle sub-stages from iterations
+        base_targets = [t.split("@")[0] for t in targets]
+        stages_to_check = {
+            name: stage
+            for name, stage in stages.items()
+            if name in base_targets
+        }
+    else:
+        stages_to_check = stages
+
+    for name, stage in stages_to_check.items():
+        deps.extend(stage.get("dependencies", []))
+
     if "git" not in deps:
         deps.append("git")
     # Resolve TTY interactivity once so a single per-call answer drives

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -188,6 +188,7 @@ class Stage(BaseModel):
     # TODO: Support other input types
     inputs: list[str | InputsFromStageOutputs] = []
     outputs: list[str | PathOutput] = []  # TODO: Support database outputs
+    dependencies: list[str | dict[str, str] | dict] = []
     always_run: bool = False
     iterate_over: list[StageIteration] | None = None
     description: str | None = None

--- a/calkit/tests/test_dependencies.py
+++ b/calkit/tests/test_dependencies.py
@@ -275,3 +275,37 @@ def test_check_system_deps_setup_kind(tmp_dir):
     ck_info["dependencies"][1]["check_command"] = "false"
     with pytest.raises(ValueError, match="auth-thing"):
         calkit.check_system_deps(ck_info=ck_info, interactive=False)
+
+
+def test_check_system_deps_stage_scoped(tmp_dir):
+    ck_info = {
+        "pipeline": {
+            "stages": {
+                "s1": {
+                    "kind": "command",
+                    "command": "echo 1",
+                    "dependencies": [{"name": "fakeapp999", "kind": "app"}],
+                },
+                "s2": {
+                    "kind": "command",
+                    "command": "echo 2",
+                    "dependencies": [],
+                },
+            }
+        }
+    }
+
+    # If we check everything, it fails because fakeapp999 doesn't exist
+    with pytest.raises(ValueError, match="fakeapp999"):
+        calkit.check_system_deps(ck_info=ck_info, interactive=False)
+
+    # If we only check s2, it should succeed
+    calkit.check_system_deps(
+        ck_info=ck_info, targets=["s2"], interactive=False
+    )
+
+    # If we check s1, it fails
+    with pytest.raises(ValueError, match="fakeapp999"):
+        calkit.check_system_deps(
+            ck_info=ck_info, targets=["s1"], interactive=False
+        )


### PR DESCRIPTION
## What this does

Closes #1029.

Right now system dependencies listed under `dependencies:` (like docker or matlab) are checked for the whole project. So a stage that needs neither still fails with an error like `app 'matlab' not found`.

This change lets you scope a system dependency to specific stages, so only the stages that actually need it are blocked when it's missing. Stages that don't need matlab can run even without a matlab license installed.

## Changes
- `calkit/core.py` — dependency-checking logic now respects stage scope
- `calkit/models/pipeline.py` — model updated to allow declaring a dependency per stage
- `calkit/cli/main/core.py` — small wiring change
- `calkit/tests/test_dependencies.py` — tests covering scoped dependencies

## Testing
- `test_dependencies.py` passes locally (10 tests)
- pre-commit passes (ruff, ruff-format, prettier, etc.)
- Didn't run the full suite locally (needs Julia/Conda/Docker/TeX); relying on CI for that

Happy to adjust the approach or the config shape if you'd prefer something different.