### PR TITLE
Fix ignored DVC zip pointers

### DIFF
--- a/calkit/dvc/zip.py
+++ b/calkit/dvc/zip.py
@@ -548,6 +548,12 @@ def _sync_one(
     if zip_deleted and direction == "to-zip":
         typer.echo(f"Rezipping '{workspace_path}' (zip was deleted)")
         zip_(workspace_path=workspace_path, zip_path=zip_path)
+        try:
+            repo = calkit.git.get_repo(wdir)
+        except calkit.git.InvalidGitRepositoryError:
+            pass
+        else:
+            calkit.git.ensure_dvc_pointer_is_not_ignored(repo, zip_path)
         run_dvc_command(["add", zip_path], cwd=wdir)
         zip_hash = get_hash(zip_path, wdir=wdir)
     # Workspace was deleted but zip exists and direction is to-workspace:
@@ -570,6 +576,12 @@ def _sync_one(
     if workspace_changed and (direction in ["to-zip", "both"]):
         typer.echo(f"Zipping '{workspace_path}' (workspace has changed)")
         zip_(workspace_path=workspace_path, zip_path=zip_path)
+        try:
+            repo = calkit.git.get_repo(wdir)
+        except calkit.git.InvalidGitRepositoryError:
+            pass
+        else:
+            calkit.git.ensure_dvc_pointer_is_not_ignored(repo, zip_path)
         run_dvc_command(["add", zip_path], cwd=wdir)
         zip_hash = get_hash(zip_path, wdir=wdir)
     # If we unzip, we need to update the hash

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -339,20 +339,45 @@ def ensure_path_is_not_ignored(
     return True
 
 
-def ensure_dvc_pointer_is_not_ignored(repo, path: str) -> None:
+def ensure_dvc_pointer_is_not_ignored(repo: git.Repo, path: str) -> None:
     """Ensure the .dvc pointer for ``path`` will not be Git-ignored.
 
     A broad pattern in a ``.gitignore`` (e.g. ``*.pdf*``) can also match the
     ``<path>.dvc`` pointer DVC commits to Git, causing ``dvc add`` to fail with
-    "bad DVC file name ... is git-ignored". This appends a ``!*.dvc`` negation
-    to the ``.gitignore`` in the pointer's own directory (which wins under Git
-    precedence) so pointers stay tracked. Idempotent.
+    "bad DVC file name ... is git-ignored". Unignore the pointer and any
+    excluded ancestor directories before adding a local ``!*.dvc`` fallback.
+    Idempotent.
     """
+    repo, path = _resolve_repo_and_ignore_path(repo, path)
     path = path.replace("\\", "/").rstrip("/")
     pointer = path + ".dvc"
     if pointer not in repo.ignored(pointer):
         return
+    matching_gitignore_path, matched_pattern = _get_matching_gitignore_details(
+        repo, pointer
+    )
+    if (
+        matching_gitignore_path is not None
+        and matched_pattern is not None
+        and not matched_pattern.startswith("!")
+        and matched_pattern.endswith("/")
+    ):
+        with open(matching_gitignore_path, encoding="utf-8") as f:
+            gitignore_txt = f.read()
+        lines = gitignore_txt.splitlines()
+        directory_pattern = matched_pattern.rstrip("/")
+        if "/" not in directory_pattern:
+            replacement = f"**/{directory_pattern}/*"
+        else:
+            replacement = directory_pattern + "/*"
+        lines[lines.index(matched_pattern)] = replacement
+        with open(matching_gitignore_path, "w", encoding="utf-8") as f:
+            f.write("\n".join(lines))
+            if gitignore_txt.endswith("\n"):
+                f.write("\n")
     pointer_dir = os.path.dirname(pointer)
+    ensure_path_is_not_ignored(repo, pointer_dir)
+    ensure_path_is_not_ignored(repo, pointer)
     gitignore_path = os.path.join(repo.working_dir, pointer_dir, ".gitignore")
     exception = "!*.dvc"
     existing_lines = []

--- a/calkit/git.py
+++ b/calkit/git.py
@@ -370,7 +370,8 @@ def ensure_dvc_pointer_is_not_ignored(repo: git.Repo, path: str) -> None:
             replacement = f"**/{directory_pattern}/*"
         else:
             replacement = directory_pattern + "/*"
-        lines[lines.index(matched_pattern)] = replacement
+        matched_index = len(lines) - 1 - lines[::-1].index(matched_pattern)
+        lines[matched_index] = replacement
         with open(matching_gitignore_path, "w", encoding="utf-8") as f:
             f.write("\n".join(lines))
             if gitignore_txt.endswith("\n"):

--- a/calkit/tests/dvc/test_zip.py
+++ b/calkit/tests/dvc/test_zip.py
@@ -3,6 +3,8 @@
 import os
 import shutil
 
+import dvc.repo
+import git
 import pytest
 from sqlitedict import SqliteDict
 
@@ -328,3 +330,26 @@ def test_sync_one(tmp_dir, monkeypatch):
     assert not os.path.exists(zip_out9)
     assert get_sync_record(str(src9.as_posix())) is None
     assert (src9 / "a.txt").read_text() == "hello"
+
+
+def test_sync_one_unignores_dvc_pointer(tmp_dir):
+    repo = git.Repo.init()
+    dvc.repo.Repo.init()
+    workspace_path = "test-results/aor"
+    os.makedirs(workspace_path)
+    with open(f"{workspace_path}/result.txt", "w") as f:
+        f.write("result")
+    unrelated_path = "other/test-results/private.txt"
+    os.makedirs(os.path.dirname(unrelated_path))
+    with open(unrelated_path, "w") as f:
+        f.write("private")
+    with open(".gitignore", "w") as f:
+        f.write("test-results/\n")
+    zip_path = make_zip_path(workspace_path)
+    pointer_path = zip_path + ".dvc"
+    assert pointer_path in repo.ignored(pointer_path)
+    assert unrelated_path in repo.ignored(unrelated_path)
+    sync_one(workspace_path, zip_path, direction="to-zip")
+    assert os.path.isfile(pointer_path)
+    assert pointer_path not in repo.ignored(pointer_path)
+    assert unrelated_path in repo.ignored(unrelated_path)

--- a/calkit/tests/test_git.py
+++ b/calkit/tests/test_git.py
@@ -399,3 +399,23 @@ def test_ensure_path_is_ignored_stale_negation_after_direct_rule(tmp_dir):
         lines = f.read().splitlines()
     assert "!results/output.json" not in lines
     assert "results/output.json" in lines
+
+
+def test_ensure_dvc_pointer_replaces_last_duplicate_directory_rule(tmp_dir):
+    repo = git.Repo.init()
+    pointer = "nested/test-results/archive.zip.dvc"
+    os.makedirs(os.path.dirname(pointer), exist_ok=True)
+    with open(".gitignore", "w") as f:
+        f.write("test-results/\n# Duplicate rule\ntest-results/\n")
+    assert repo.ignored(pointer)
+    calkit.git.ensure_dvc_pointer_is_not_ignored(
+        repo, path=pointer.removesuffix(".dvc")
+    )
+    with open(".gitignore") as f:
+        lines = f.read().splitlines()
+    assert lines[:3] == [
+        "test-results/",
+        "# Duplicate rule",
+        "**/test-results/*",
+    ]
+    assert not repo.ignored(pointer)


### PR DESCRIPTION
## Summary

- protect generated dvc-zip pointer files before running DVC add
- preserve broad directory ignore semantics while making pointer exceptions visible to DVC
- keep zip synchronization working outside Git repositories

## Validation

- `uv run pytest calkit/tests/dvc/test_zip.py::test_sync_one_unignores_dvc_pointer -q`
- `uv run pytest calkit/tests/test_git.py calkit/tests/dvc/test_zip.py -q`
- `uv run pre-commit run --files calkit/git.py calkit/dvc/zip.py calkit/tests/dvc/test_zip.py`
- `git diff --check`

resolves #1044