### PR TITLE
Handle object-form stage inputs in sidebar tree (fixes #1031)

### DIFF
--- a/vscode-ext/src/pipeline/core.ts
+++ b/vscode-ext/src/pipeline/core.ts
@@ -171,3 +171,13 @@ export function classifyStaleStage(
     extraModifiedInputs,
   };
 }
+
+// Normalize a stage dep/out entry to its path string. Calkit writes these
+// as either a plain string or an object carrying a `path` (e.g. an out with
+// `cache: false`); the sidebar routes every input/output row through this
+// before building a filesystem path. Kept vscode-free so it can be tested.
+export function outputEntryPath(
+  output: string | { path: string; [key: string]: unknown },
+): string {
+  return typeof output === "string" ? output : output.path;
+}

--- a/vscode-ext/src/sidebar.ts
+++ b/vscode-ext/src/sidebar.ts
@@ -23,9 +23,17 @@ import {
 // artifact-style sections (figures, datasets, results, publications,
 // presentations), which share the same item machinery.
 type ArtifactKind =
-  "figure" | "dataset" | "result" | "publication" | "presentation";
+  | "figure"
+  | "dataset"
+  | "result"
+  | "publication"
+  | "presentation";
 type ArtifactCollection =
-  "figures" | "datasets" | "results" | "publications" | "presentations";
+  | "figures"
+  | "datasets"
+  | "results"
+  | "publications"
+  | "presentations";
 
 // The displayed text of a question, which may be a plain string or a structured
 // entry carrying a hypothesis/answer/evidence alongside the question itself.
@@ -54,7 +62,9 @@ export class SidebarItem extends vscode.TreeItem {
   }
 }
 
-export class CalkitSidebarProvider implements vscode.TreeDataProvider<SidebarItem> {
+export class CalkitSidebarProvider
+  implements vscode.TreeDataProvider<SidebarItem>
+{
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<
     SidebarItem | undefined | null | void
   >();
@@ -1038,20 +1048,20 @@ export class CalkitSidebarProvider implements vscode.TreeDataProvider<SidebarIte
       item.iconPath = isRunning
         ? new vscode.ThemeIcon("loading~spin")
         : isStale
-          ? new vscode.ThemeIcon(
-              "warning",
-              new vscode.ThemeColor("list.warningForeground"),
-            )
-          : new vscode.ThemeIcon(
-              "check",
-              new vscode.ThemeColor("testing.iconPassed"),
-            );
+        ? new vscode.ThemeIcon(
+            "warning",
+            new vscode.ThemeColor("list.warningForeground"),
+          )
+        : new vscode.ThemeIcon(
+            "check",
+            new vscode.ThemeColor("testing.iconPassed"),
+          );
       item.contextValue = "stage";
       item.tooltip = isRunning
         ? `${stageName} — running`
         : isStale
-          ? `${stageName} — stage is stale`
-          : `${stageName} — up to date`;
+        ? `${stageName} — stage is stale`
+        : `${stageName} — up to date`;
       this.stageItemCache.set(stageName, item);
       return item;
     });
@@ -1119,8 +1129,8 @@ export class CalkitSidebarProvider implements vscode.TreeDataProvider<SidebarIte
       cls?.modifiedOutputs.has(p)
         ? "modified"
         : cls?.staleOutputs.has(p)
-          ? "stale"
-          : undefined;
+        ? "stale"
+        : undefined;
 
     const prop = (
       label: string,
@@ -1239,10 +1249,10 @@ export class CalkitSidebarProvider implements vscode.TreeDataProvider<SidebarIte
             (p) => !p.startsWith(".calkit/scheduler/logs/"),
           )
         : Array.isArray(calkitStage.outputs)
-          ? (calkitStage.outputs as (string | { path: string })[]).map(
-              outputEntryPath,
-            )
-          : [];
+        ? (calkitStage.outputs as (string | { path: string })[]).map(
+            outputEntryPath,
+          )
+        : [];
       for (const output of explicitOutputs) {
         prop("Output", output, "arrow-right", output, outputStaleKind(output));
       }

--- a/vscode-ext/src/sidebar.ts
+++ b/vscode-ext/src/sidebar.ts
@@ -16,29 +16,16 @@ import {
   classifyStaleStage,
   dvcStageOutputPaths,
   type StaleClassification,
+  outputEntryPath,
 } from "./pipeline/core";
 
 // Singular node kinds and the matching calkit.yaml collection keys for the
 // artifact-style sections (figures, datasets, results, publications,
 // presentations), which share the same item machinery.
 type ArtifactKind =
-  | "figure"
-  | "dataset"
-  | "result"
-  | "publication"
-  | "presentation";
+  "figure" | "dataset" | "result" | "publication" | "presentation";
 type ArtifactCollection =
-  | "figures"
-  | "datasets"
-  | "results"
-  | "publications"
-  | "presentations";
-
-function outputEntryPath(
-  output: string | { path: string; [key: string]: unknown },
-): string {
-  return typeof output === "string" ? output : output.path;
-}
+  "figures" | "datasets" | "results" | "publications" | "presentations";
 
 // The displayed text of a question, which may be a plain string or a structured
 // entry carrying a hypothesis/answer/evidence alongside the question itself.
@@ -67,9 +54,7 @@ export class SidebarItem extends vscode.TreeItem {
   }
 }
 
-export class CalkitSidebarProvider
-  implements vscode.TreeDataProvider<SidebarItem>
-{
+export class CalkitSidebarProvider implements vscode.TreeDataProvider<SidebarItem> {
   private readonly _onDidChangeTreeData = new vscode.EventEmitter<
     SidebarItem | undefined | null | void
   >();
@@ -752,9 +737,8 @@ export class CalkitSidebarProvider
         arguments: [stageItem],
       };
       items.push(stageItem);
-      for (const input of Array.isArray(stage.inputs)
-        ? (stage.inputs as string[])
-        : []) {
+      for (const rawInput of Array.isArray(stage.inputs) ? stage.inputs : []) {
+        const input = outputEntryPath(rawInput as string | { path: string });
         const inputItem = new SidebarItem(
           "Input",
           vscode.TreeItemCollapsibleState.None,
@@ -1054,20 +1038,20 @@ export class CalkitSidebarProvider
       item.iconPath = isRunning
         ? new vscode.ThemeIcon("loading~spin")
         : isStale
-        ? new vscode.ThemeIcon(
-            "warning",
-            new vscode.ThemeColor("list.warningForeground"),
-          )
-        : new vscode.ThemeIcon(
-            "check",
-            new vscode.ThemeColor("testing.iconPassed"),
-          );
+          ? new vscode.ThemeIcon(
+              "warning",
+              new vscode.ThemeColor("list.warningForeground"),
+            )
+          : new vscode.ThemeIcon(
+              "check",
+              new vscode.ThemeColor("testing.iconPassed"),
+            );
       item.contextValue = "stage";
       item.tooltip = isRunning
         ? `${stageName} — running`
         : isStale
-        ? `${stageName} — stage is stale`
-        : `${stageName} — up to date`;
+          ? `${stageName} — stage is stale`
+          : `${stageName} — up to date`;
       this.stageItemCache.set(stageName, item);
       return item;
     });
@@ -1119,7 +1103,9 @@ export class CalkitSidebarProvider
                 ? calkitStage.target_path
                 : undefined,
             configuredInputs: Array.isArray(calkitStage.inputs)
-              ? (calkitStage.inputs as string[])
+              ? (calkitStage.inputs as (string | { path: string })[]).map(
+                  outputEntryPath,
+                )
               : [],
             envFilePaths:
               typeof calkitStage.environment === "string"
@@ -1133,8 +1119,8 @@ export class CalkitSidebarProvider
       cls?.modifiedOutputs.has(p)
         ? "modified"
         : cls?.staleOutputs.has(p)
-        ? "stale"
-        : undefined;
+          ? "stale"
+          : undefined;
 
     const prop = (
       label: string,
@@ -1226,9 +1212,10 @@ export class CalkitSidebarProvider
           this.makeEnvPropItem(calkitStage.environment, cls?.envStale),
         );
       }
-      for (const input of Array.isArray(calkitStage.inputs)
-        ? (calkitStage.inputs as string[])
+      for (const rawInput of Array.isArray(calkitStage.inputs)
+        ? (calkitStage.inputs as (string | { path: string })[])
         : []) {
+        const input = outputEntryPath(rawInput);
         prop(
           "Input",
           input,
@@ -1252,10 +1239,10 @@ export class CalkitSidebarProvider
             (p) => !p.startsWith(".calkit/scheduler/logs/"),
           )
         : Array.isArray(calkitStage.outputs)
-        ? (calkitStage.outputs as (string | { path: string })[]).map(
-            outputEntryPath,
-          )
-        : [];
+          ? (calkitStage.outputs as (string | { path: string })[]).map(
+              outputEntryPath,
+            )
+          : [];
       for (const output of explicitOutputs) {
         prop("Output", output, "arrow-right", output, outputStaleKind(output));
       }

--- a/vscode-ext/src/test/pipeline.test.ts
+++ b/vscode-ext/src/test/pipeline.test.ts
@@ -4,6 +4,7 @@ import {
   classifyStaleStage,
   dvcStageOutputPaths,
   expandDvcMatrix,
+  outputEntryPath,
 } from "../pipeline/core";
 
 test("expandDvcMatrix produces the cartesian product, flattening nested values", () => {
@@ -147,4 +148,18 @@ test("classifyStaleStage reports a changed command", () => {
   );
   assert.equal(cls.commandModified, true);
   assert.equal(cls.scriptStale, false);
+});
+
+test("outputEntryPath normalizes string and object-form deps/outs", () => {
+  // Regression for #1031: object-form inputs/outputs (e.g. a dep written as
+  // `- path: data.csv`, or an out carrying `cache: false`) reached path.join
+  // as objects and crashed stage/notebook expansion. Every input/output row in
+  // the sidebar routes through this helper, so both shapes must resolve to a
+  // plain string path.
+  assert.equal(outputEntryPath("data/raw.csv"), "data/raw.csv");
+  assert.equal(outputEntryPath({ path: "data/raw.csv" }), "data/raw.csv");
+  assert.equal(
+    outputEntryPath({ path: "results/out.json", cache: false }),
+    "results/out.json",
+  );
 });

--- a/vscode-ext/src/test/sidebar.test.ts
+++ b/vscode-ext/src/test/sidebar.test.ts
@@ -53,7 +53,10 @@ after(() => {
   (Module as any).prototype.require = originalRequire;
 });
 
-import { CalkitSidebarProvider, SidebarItem } from "../sidebar";
+// Loaded via runtime require (not a static import) so it resolves AFTER the
+// require patch above, regardless of TS import-hoisting.
+const { CalkitSidebarProvider, SidebarItem } =
+  require("../sidebar") as typeof import("../sidebar");
 
 test("sidebar provider does not throw on object-form inputs in getStageProps", () => {
   const provider = new CalkitSidebarProvider();

--- a/vscode-ext/src/test/sidebar.test.ts
+++ b/vscode-ext/src/test/sidebar.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+// Create minimal vscode stub
+const vscodeStub = {
+  TreeItem: class TreeItem {
+    label: string;
+    collapsibleState: number;
+    description?: string;
+    iconPath?: any;
+    command?: any;
+    tooltip?: string;
+    constructor(label: string, collapsibleState: number) {
+      this.label = label;
+      this.collapsibleState = collapsibleState;
+    }
+  },
+  EventEmitter: class EventEmitter {
+    event = {};
+    fire() {}
+  },
+  ThemeIcon: class ThemeIcon {
+    constructor(
+      public readonly id: string,
+      public readonly color?: any,
+    ) {}
+  },
+  ThemeColor: class ThemeColor {
+    constructor(public readonly id: string) {}
+  },
+  TreeItemCollapsibleState: {
+    None: 0,
+    Collapsed: 1,
+    Expanded: 2,
+  },
+  Uri: {
+    file: (f: string) => ({ fsPath: f, scheme: "file", path: f }),
+  },
+};
+
+// Inject it into require cache before importing sidebar.ts
+import * as Module from "node:module";
+const originalRequire = (Module as any).prototype.require;
+(Module as any).prototype.require = function (id: string) {
+  if (id === "vscode") {
+    return vscodeStub;
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+import { CalkitSidebarProvider, SidebarItem } from "../sidebar";
+
+test("sidebar provider does not throw on object-form inputs in getStageProps", () => {
+  const provider = new CalkitSidebarProvider();
+
+  provider.refresh(
+    "/workspace",
+    {
+      pipeline: {
+        stages: {
+          teststage: {
+            kind: "command",
+            inputs: ["plain.txt", { path: "data/raw.csv" } as any],
+          },
+        },
+      },
+    },
+    undefined,
+    new Set(),
+  );
+
+  // We can synthesize a stage item and pass it to getChildren.
+  const stageItem = new SidebarItem(
+    "teststage",
+    vscodeStub.TreeItemCollapsibleState.None,
+    "stage",
+    "teststage",
+  );
+  const children = provider.getChildren(stageItem);
+
+  assert.ok(Array.isArray(children));
+
+  // Verify that an Input row for 'data/raw.csv' exists
+  const hasRawCsv = children.some((c) => c.description === "data/raw.csv");
+  assert.ok(hasRawCsv, "Should find input row with description data/raw.csv");
+});

--- a/vscode-ext/src/test/sidebar.test.ts
+++ b/vscode-ext/src/test/sidebar.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import test from "node:test";
+import test, { after } from "node:test";
 
 // Create minimal vscode stub
 const vscodeStub = {
@@ -47,6 +47,11 @@ const originalRequire = (Module as any).prototype.require;
   }
   return originalRequire.apply(this, arguments);
 };
+
+// Restore the real require so the patch does not leak into other test files.
+after(() => {
+  (Module as any).prototype.require = originalRequire;
+});
 
 import { CalkitSidebarProvider, SidebarItem } from "../sidebar";
 


### PR DESCRIPTION
Fixes #1031

## Problem
Expanding a Python-script or Jupyter-notebook stage in the sidebar threw:

    TypeError: The "path" argument must be of type string. Received an instance of Object

VS Code surfaced this as an error notification and the entire stage subtree
failed to expand. Shell-script stages were unaffected.

## Cause
A stage's inputs and outputs can each be either a plain string or an object of
the form `{ path, ... }` (e.g. a dep written as `- path: x.csv`, or an out
carrying `cache: false`). In the sidebar's `getStageProps`, the outputs loop
already normalized each entry through `outputEntryPath()` before building a
path, but the inputs loop passed each entry straight into
`path.join(workspaceRoot, input)`. When an input was object-form, `path.join`
threw `ERR_INVALID_ARG_TYPE`, rejecting the `getChildren` promise so no
children rendered — not just the offending row. Shell stages use plain-string
deps, which is why only Python/notebook stages broke.

The same unguarded pattern existed in `getNotebookProps`, and the object case
was also passed unnormalized into `classifyStaleStage` via `configuredInputs`.

## Fix
- Route inputs through `outputEntryPath()` in both `getStageProps` and
  `getNotebookProps`, matching the existing outputs handling.
- Normalize `configuredInputs` before passing them to `classifyStaleStage`.
- Move `outputEntryPath` from sidebar.ts into pipeline/core.ts (the vscode-free
  helper module) and export it, so it can be unit-tested under `node --test`.

No behavior change for string-form entries; object-form entries now resolve to
their `.path`.

## Tests
- `pipeline.test.ts`: unit test that `outputEntryPath` normalizes both string
  and object forms.
- `sidebar.test.ts`: provider-level regression test that drives `getStageProps`
  via `getChildren` with an object-form input, asserting it renders the Input
  row without throwing. Verified it fails with the original `ERR_INVALID_ARG_TYPE`
  when the normalization is reverted, and passes with the fix.