### PR TITLE
Show answered status for project questions

### DIFF
--- a/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/index.tsx
+++ b/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/index.tsx
@@ -5,6 +5,7 @@ import {
   AccordionIcon,
   AccordionItem,
   AccordionPanel,
+  Badge,
   Box,
   Checkbox,
   Flex,
@@ -502,6 +503,11 @@ function ProjectView() {
                                 {`${question.number}. ${question.question}`}
                               </Markdown>
                             </Box>
+                            {question.answer ? (
+                              <Badge colorScheme="green" mx={2}>
+                                answered
+                              </Badge>
+                            ) : null}
                             <AccordionIcon />
                           </AccordionButton>
                         ) : (

--- a/vscode-ext/src/sidebar.ts
+++ b/vscode-ext/src/sidebar.ts
@@ -428,6 +428,9 @@ export class CalkitSidebarProvider
         String(index),
       );
       item.iconPath = new vscode.ThemeIcon("question");
+      if (typeof question !== "string" && question.answer) {
+        item.description = "answered";
+      }
       item.tooltip = text;
       item.contextValue = "question";
       return item;

--- a/vscode-ext/src/test/sidebar.test.ts
+++ b/vscode-ext/src/test/sidebar.test.ts
@@ -92,3 +92,40 @@ test("sidebar provider does not throw on object-form inputs in getStageProps", (
   const hasRawCsv = children.some((c) => c.description === "data/raw.csv");
   assert.ok(hasRawCsv, "Should find input row with description data/raw.csv");
 });
+
+test("question items mark only answered entries while preserving expansion", () => {
+  const provider = new CalkitSidebarProvider();
+  provider.refresh(
+    "/workspace",
+    {
+      questions: [
+        { question: "Answered question", answer: "A result" },
+        { question: "Question with hypothesis", hypothesis: "An idea" },
+        { question: "Question with empty answer", answer: "" },
+        "Plain question",
+      ],
+    },
+    undefined,
+    new Set(),
+  );
+  const section = new SidebarItem(
+    "Questions",
+    vscodeStub.TreeItemCollapsibleState.Collapsed,
+    "section-questions",
+  );
+  const items = provider.getChildren(section);
+  assert.deepEqual(
+    items.map((item) => [item.label, item.description]),
+    [
+      ["Answered question", "answered"],
+      ["Question with hypothesis", undefined],
+      ["Question with empty answer", undefined],
+      ["Plain question", undefined],
+    ],
+  );
+  assert.equal(
+    items[0].collapsibleState,
+    vscodeStub.TreeItemCollapsibleState.Collapsed,
+  );
+  assert.equal(provider.getChildren(items[0])[0].description, "A result");
+});


### PR DESCRIPTION
## Summary
- show an `answered` badge for questions with a non-empty answer in the Hub frontend
- show an `answered` description for the same questions in the VS Code sidebar
- preserve the existing click-to-expand behavior for hypothesis, answer, and evidence
- cover answered, unanswered, empty-answer, and plain-string VS Code entries

## Testing
- Hub frontend: `npx tsc`
- Hub frontend: production Vite build
- VS Code extension: `npm test` (35 passed)

Resolves #1083