### PR TITLE
Job summary 1510

### DIFF
--- a/calkit/cli/scheduler.py
+++ b/calkit/cli/scheduler.py
@@ -67,6 +67,7 @@ QUEUE_SLOT_POLL_JITTER = 0.25
 # When set, scheduler commands run jobs on the local host instead of
 # dispatching to a real SLURM/PBS install (see _mock_enabled).
 MOCK_ENV_VAR = "CALKIT_MOCK_SCHEDULER"
+SUMMARY_ENV_VAR = "CALKIT_JOB_SUMMARY_PATH"
 
 
 # A generous busy timeout lets the many batch processes that fan out an
@@ -673,6 +674,59 @@ def _wait_until_done(kind: str, job_id: str, name: str) -> int | None:
         raise typer.Exit(130)
 
 
+def _summary_path(log_path: str) -> str:
+    from calkit.models.pipeline import summary_path_from_log_path
+
+    return summary_path_from_log_path(log_path)
+
+
+def _merge_job_summary(name: str, summary_path: str) -> None:
+    """Merge calkit metadata into a job-written summary file, if present."""
+    if not os.path.isfile(summary_path):
+        return
+    import json
+
+    try:
+        with open(summary_path, "rb") as f:
+            raw = f.read()
+    except OSError:
+        return
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        warn(
+            f"Job '{name}' summary at {summary_path} is not valid JSON; "
+            "leaving it unchanged"
+        )
+        return
+    if not isinstance(payload, dict):
+        warn(
+            f"Job '{name}' summary at {summary_path} is not a JSON object; "
+            "leaving it unchanged"
+        )
+        return
+    info = _load_jobs().get(name)
+    if info is None:
+        return
+    if "calkit" in payload:
+        warn(
+            f"Job '{name}' summary at {summary_path} contains a reserved "
+            "'calkit' key; overwriting it with calkit metadata"
+        )
+    payload["calkit"] = {
+        "name": name,
+        "job_id": info.get("job_id"),
+        "kind": info.get("kind"),
+        "exit_code": info.get("exit_code"),
+        "submitted_at": info.get("submitted_at"),
+        "finished_at": info.get("finished_at"),
+        "dep_md5s": info.get("dep_md5s"),
+    }
+    with open(summary_path, "w") as f:
+        json.dump(payload, f, sort_keys=True, indent=2)
+        f.write("\n")
+
+
 def _wait_for_output_file(log_path: str, timeout: float = 120.0) -> None:
     """Wait for a finished job's output log to be fully written.
 
@@ -729,6 +783,7 @@ def _finalize_job(
     # staged back before we read from or point at it.
     if not _mock_enabled():
         _wait_for_output_file(log_path)
+    _merge_job_summary(name, _summary_path(log_path))
     if exit_code is None:
         warn(
             f"Could not determine exit status for job '{name}' (ID {job_id}); "
@@ -1071,6 +1126,11 @@ def run_batch(
                 raise typer.Exit(0)
     # Job is not running or queued, so we can submit. First, delete any
     # non-persistent outputs.
+    summary_path = os.path.abspath(_summary_path(log_path))
+    os.environ[SUMMARY_ENV_VAR] = summary_path
+    if os.path.isfile(summary_path):
+        typer.echo(f"Deleting stale summary at '{summary_path}'")
+        os.remove(summary_path)
     for out in outs:
         if os.path.exists(out):
             typer.echo(f"Deleting output path '{out}'")

--- a/calkit/models/pipeline.py
+++ b/calkit/models/pipeline.py
@@ -58,6 +58,15 @@ RelativeChildPathString = Annotated[
 ]
 
 
+def summary_path_from_log_path(log_path: str) -> str:
+    """Derive a scheduler job's summary path from its log path.
+
+    Shared so the CLI, which tells the job where to write, and the stage
+    definition, which declares the file as an output, cannot disagree.
+    """
+    return os.path.splitext(log_path)[0] + ".summary.json"
+
+
 class StageIteration(BaseModel):
     """A model for the ``iterate_over`` key in a stage definition.
 
@@ -162,6 +171,7 @@ class StageSchedulerOptions(BaseModel):
     env_default_setup: EnvDefaultsMode = "replace"
     log_path: str | None = None
     log_storage: Literal["git", "dvc"] | None = "git"
+    summary: bool = False
 
 
 class Stage(BaseModel):
@@ -403,6 +413,27 @@ class Stage(BaseModel):
             delete_before_run=False,
         )
 
+    @property
+    def scheduler_summary_output(self) -> PathOutput | None:
+        """The structured summary file for a scheduler-batched stage.
+
+        Opt in via ``scheduler.summary: true``. The path mirrors the stage log
+        (``.calkit/scheduler/logs/<name>.summary.json`` by default).
+        """
+        if self.scheduler is None or self._scheduler_kind is None:
+            return None
+        if not self.scheduler.summary:
+            return None
+        log_out = self.scheduler_log_output
+        if log_out is None:
+            return None
+        summary_path = summary_path_from_log_path(log_out.path)
+        return PathOutput(
+            path=summary_path,
+            storage=self.scheduler.log_storage,
+            delete_before_run=False,
+        )
+
     def to_dvc(self) -> dict:
         """Convert to a DVC stage.
 
@@ -427,6 +458,18 @@ class Stage(BaseModel):
                 isinstance(o, dict) and log_out.path in o for o in outs
             ):
                 outs.append(log_entry)
+        summary_out = self.scheduler_summary_output
+        if summary_out is not None:
+            summary_entry = {
+                summary_out.path: {
+                    "cache": summary_out.storage == "dvc",
+                    "persist": True,
+                }
+            }
+            if not any(
+                isinstance(o, dict) and summary_out.path in o for o in outs
+            ):
+                outs.append(summary_entry)
         # Scheduler-batched stages must persist their outputs: `calkit
         # scheduler batch` deletes and recreates them itself, and persisting
         # stops DVC from removing them before a re-run. That lets a job that
@@ -1429,6 +1472,8 @@ class Pipeline(BaseModel):
                     sched_opts["env_default_setup"] = (
                         stage.scheduler.env_default_setup
                     )
+                if stage.scheduler.summary:
+                    sched_opts["summary"] = True
             new_stage = ShellScriptStage(
                 kind="shell-script",
                 name=name,

--- a/calkit/tests/cli/test_scheduler.py
+++ b/calkit/tests/cli/test_scheduler.py
@@ -1,14 +1,17 @@
 """Tests for ``calkit.cli.scheduler``."""
 
+import json
 import os
 import subprocess
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 import pytest
 import typer
 
+import calkit
 import calkit.cli.scheduler as sched
 from calkit.cli.scheduler import (
     _active_job_ids,
@@ -19,6 +22,7 @@ from calkit.cli.scheduler import (
     _finalize_job,
     _is_active,
     _load_jobs,
+    _merge_job_summary,
     _mock_enabled,
     _mock_submit,
     _parse_slurm_exit_code,
@@ -27,8 +31,10 @@ from calkit.cli.scheduler import (
     _record_job_result,
     _sanitize_pbs_job_name,
     _slurm_exit_code,
+    _summary_path,
     _wait_for_output_file,
     _wait_until_done,
+    run_batch,
 )
 
 
@@ -609,3 +615,133 @@ def test_queue_lock_is_exclusive(tmp_dir):
     # Whoever went first finished before the other started.
     assert order[0].startswith("enter")
     assert order[1] == order[0].replace("enter", "exit")
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="TODO: mock scheduler invokes a .sh script directly; not portable to Windows",
+)
+def test_job_summary(tmp_dir, monkeypatch):
+    warnings: list[str] = []
+    monkeypatch.setenv("CALKIT_MOCK_SCHEDULER", "1")
+    monkeypatch.setattr(
+        "calkit.cli.scheduler.warn", lambda msg: warnings.append(msg)
+    )
+    with open("calkit.yaml", "w") as f:
+        calkit.ryaml.dump({"environments": {"slurm": {"kind": "slurm"}}}, f)
+    batch_kwargs: dict[str, Any] = dict(
+        environment="slurm",
+        deps=[],
+        outs=[],
+        options=[],
+        setup_cmds=[],
+        is_command=False,
+    )
+    # A job that writes a valid JSON object gets its payload merged with a
+    # calkit metadata block recording the observed exit code and job id.
+    with open("write_summary.sh", "w") as f:
+        f.write(
+            'printf \'{"score": 42, "gpu": "a100"}\' > '
+            '"$CALKIT_JOB_SUMMARY_PATH"\n'
+        )
+    run_batch(name="job1", target="write_summary.sh", **batch_kwargs)
+    summary_path = ".calkit/scheduler/logs/job1.summary.json"
+    with open(summary_path) as f:
+        data = json.load(f)
+    assert data["score"] == 42
+    assert data["gpu"] == "a100"
+    job_id = _load_jobs()["job1"]["job_id"]
+    assert data["calkit"]["job_id"] == job_id
+    assert data["calkit"]["exit_code"] == 0
+    # A job that writes nothing leaves no summary file behind.
+    with open("no_summary.sh", "w") as f:
+        f.write("echo hello\n")
+    run_batch(name="job2", target="no_summary.sh", **batch_kwargs)
+    assert not os.path.exists(".calkit/scheduler/logs/job2.summary.json")
+    # A reserved top-level ``calkit`` key is overwritten and warned about.
+    with open("reserved_key.sh", "w") as f:
+        f.write(
+            'printf \'{"calkit": {"fake": 1}, "score": 1}\' > '
+            '"$CALKIT_JOB_SUMMARY_PATH"\n'
+        )
+    warnings.clear()
+    run_batch(name="job3", target="reserved_key.sh", **batch_kwargs)
+    assert any("reserved" in w for w in warnings)
+    with open(".calkit/scheduler/logs/job3.summary.json") as f:
+        reserved_data = json.load(f)
+    assert "fake" not in reserved_data["calkit"]
+    assert reserved_data["calkit"]["name"] == "job3"
+    # A top-level JSON list, and separately malformed JSON, are left untouched.
+    for rel_path, raw in [
+        ("list.summary.json", b"[1, 2, 3]\n"),
+        ("bad.summary.json", b"{not json\n"),
+    ]:
+        warnings.clear()
+        with open(rel_path, "wb") as f:
+            f.write(raw)
+        _merge_job_summary("ignored", rel_path)
+        assert warnings
+        with open(rel_path, "rb") as f:
+            assert f.read() == raw
+    # A custom ``--log-path`` places the summary next to that log, not under
+    # ``LOGS_DIR``.
+    os.makedirs("custom", exist_ok=True)
+    with open("custom_log.sh", "w") as f:
+        f.write(
+            'printf \'{"where": "custom"}\' > "$CALKIT_JOB_SUMMARY_PATH"\n'
+        )
+    run_batch(
+        name="job4",
+        target="custom_log.sh",
+        log_path="custom/run.out",
+        **batch_kwargs,
+    )
+    assert os.path.isfile("custom/run.summary.json")
+    assert not os.path.exists(".calkit/scheduler/logs/job4.summary.json")
+    # A failing job still writes its summary before the failure is surfaced.
+    with open("fail_summary.sh", "w") as f:
+        f.write(
+            'printf \'{"attempted": true}\' > "$CALKIT_JOB_SUMMARY_PATH"\n'
+            "exit 7\n"
+        )
+    with pytest.raises(typer.Exit) as exc:
+        run_batch(name="job5", target="fail_summary.sh", **batch_kwargs)
+    assert exc.value.exit_code == 1
+    with open(".calkit/scheduler/logs/job5.summary.json") as f:
+        fail_data = json.load(f)
+    assert fail_data["attempted"] is True
+    assert fail_data["calkit"]["exit_code"] == 7
+    # Resubmitting deletes a stale summary from a prior run before the new job
+    # starts, so leftover payloads cannot be stamped with fresh metadata.
+    stale_path = ".calkit/scheduler/logs/job6.summary.json"
+    os.makedirs(os.path.dirname(stale_path), exist_ok=True)
+    with open(stale_path, "w") as f:
+        json.dump({"stale": True}, f)
+    with open("no_summary.sh", "w") as f:
+        f.write("echo again\n")
+    run_batch(name="job6", target="no_summary.sh", **batch_kwargs)
+    assert not os.path.exists(stale_path)
+    # Re-merging an already-merged summary produces identical bytes.
+    merged_path = ".calkit/scheduler/logs/remerge.summary.json"
+    os.makedirs(os.path.dirname(merged_path), exist_ok=True)
+    with open(merged_path, "w") as f:
+        json.dump({"metric": 1}, f)
+        f.write("\n")
+    _record_job(
+        "remerge",
+        {
+            "kind": "slurm",
+            "job_id": "abc",
+            "dep_md5s": {},
+            "submitted_at": "2020-01-01T00:00:00",
+        },
+    )
+    _record_job_result("remerge", 0)
+    _merge_job_summary("remerge", merged_path)
+    with open(merged_path, "rb") as f:
+        first_bytes = f.read()
+    _merge_job_summary("remerge", merged_path)
+    with open(merged_path, "rb") as f:
+        second_bytes = f.read()
+    assert first_bytes == second_bytes
+    assert _summary_path("custom/run.out") == "custom/run.summary.json"

--- a/calkit/tests/models/test_pipeline.py
+++ b/calkit/tests/models/test_pipeline.py
@@ -385,7 +385,9 @@ def test_sbatchstage():
     - the converted stage emits ``calkit scheduler batch``,
     - sbatch_options land in scheduler.options,
     - stage-level setup commands survive the conversion,
-    - non-default env_default_* modes survive the conversion.
+    - non-default env_default_* modes survive the conversion,
+    - ``scheduler.summary: true`` declares a summary JSON output.
+    - ``summary`` survives the sbatch migration.
     """
     from calkit.models.pipeline import Pipeline, ShellScriptStage
 
@@ -470,6 +472,51 @@ def test_sbatchstage():
     sd_setup = pipeline3.stages["job-setup-ignore"].to_dvc()
     assert "--env-default-options" not in sd_setup["cmd"]
     assert "--env-default-setup ignore" in sd_setup["cmd"]
+    # Opt-in summary output is declared alongside the job log when enabled.
+    pipeline4 = Pipeline.model_validate(
+        {
+            "stages": {
+                "job-summary": {
+                    "kind": "shell-script",
+                    "name": "job-summary",
+                    "script_path": "scripts/run_job.sh",
+                    "environment": "slurm-env",
+                    "scheduler": {"summary": True},
+                }
+            }
+        }
+    )
+    stage_summary = pipeline4.stages["job-summary"]
+    stage_summary._scheduler_kind = "slurm"
+    sd_summary = stage_summary.to_dvc()
+    assert {
+        ".calkit/scheduler/logs/job-summary.out": {
+            "cache": False,
+            "persist": True,
+        }
+    } in sd_summary["outs"]
+    assert {
+        ".calkit/scheduler/logs/job-summary.summary.json": {
+            "cache": False,
+            "persist": True,
+        }
+    } in sd_summary["outs"]
+    # A migrated sbatch stage keeps its summary opt-in.
+    pipeline5 = Pipeline.model_validate(
+        {
+            "stages": {
+                "job-migrate": {
+                    "kind": "sbatch",
+                    "script_path": "scripts/run_job.sh",
+                    "environment": "slurm-env",
+                    "scheduler": {"summary": True},
+                }
+            }
+        }
+    )
+    converted5 = pipeline5.convert_sbatch_stages()
+    assert converted5["job-migrate"]["scheduler"]["summary"] is True
+    assert pipeline5.stages["job-migrate"].scheduler.summary is True
 
 
 def test_mappathsstage():

--- a/docs/hpc.md
+++ b/docs/hpc.md
@@ -232,3 +232,39 @@ CALKIT_MOCK_SCHEDULER=1 calkit run
 
 Mock job state lives under `.calkit/local/`, which is always ignored by Git,
 so it never makes its way into your project history.
+
+## Structured job summaries
+
+Scheduler jobs can write structured JSON that Calkit versions alongside the
+job log. Calkit sets the environment variable `CALKIT_JOB_SUMMARY_PATH` to an
+absolute path before your job starts; write whatever JSON object you want there
+from any language, with no Calkit import:
+
+```sh
+printf '{"max_res": 1.2e-3, "gpu": "a100-0"}' > "$CALKIT_JOB_SUMMARY_PATH"
+```
+
+When the job finishes, Calkit merges its own metadata into a reserved top-level
+`calkit` key (job name, id, exit code, timestamps, dependency MD5s). Treat
+`calkit` as reserved—if your script sets it, Calkit's block wins.
+
+By default the summary file is not a declared pipeline output, so existing
+projects are unchanged. Opt in per stage with `summary: true` under the stage's
+`scheduler:` block; Calkit then tracks the file next to the job log with the
+same treatment as the `.out` log (`cache: false`, `persist: true`):
+
+```yaml
+pipeline:
+  stages:
+    benchmark:
+      kind: shell-script
+      environment: cluster1
+      script_path: scripts/run-benchmark.sh
+      scheduler:
+        summary: true
+      outputs:
+        - results/raw
+```
+
+With the default log path, the summary lands at
+`.calkit/scheduler/logs/<stage-name>.summary.json`.


### PR DESCRIPTION
Closes #1510.

Adds a channel for scheduler jobs to write structured JSON that calkit
versions alongside the `.out` log. `CALKIT_JOB_SUMMARY_PATH` is set once in
`run_batch` — sbatch exports the environment by default, qsub already gets
`-V`, and the mock backend copies `os.environ`, so one assignment covers all
three. After the job finishes, `_finalize_job` merges what calkit already
knows (job id, kind, exit code, timestamps, dependency MD5s) under a reserved
`calkit` key.

Two things worth flagging:

- The summary path derives from `log_path` rather than `LOGS_DIR`, since
  `--log-path` is user-overridable and the two would otherwise drift. Shared
  helper so the CLI and the stage definition can't disagree.
- Stale summaries are deleted before resubmission. Since the file is
  `persist: true` it isn't in `outs`, so without this a resubmitted job that
  dies before writing leaves the previous run's payload on disk to be stamped
  with fresh metadata.

**Opt-in was my call and is the thing most worth pushing back on.** Declaring
the summary unconditionally would change every existing scheduler stage and
force a re-run of exactly the expensive jobs whose provenance is the point —
the incentive problem you raised in #1024. So it's `summary: true` under the
stage's `scheduler:` block, defaulting to false. Happy to flip it if you'd
rather take the one-time invalidation.

Auto-populated provenance (hostname, GPU UUID, ECC counters) left for a
follow-up to keep this reviewable.

Tested via the mock scheduler: valid payload merge, no-summary, reserved key
collision, malformed JSON, custom log path, failing job, stale deletion, and
re-merge byte-identity.