### PR TITLE
Migrate devcontainer, VS Code config, and GitHub Action in

### DIFF
--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -1,0 +1,44 @@
+name: Build dev container image
+
+# The default token needs no write access; the image is only pushed from
+# publish.yml, on release
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "calkit/resources/devcontainer/**"
+      - ".github/workflows/devcontainer.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      # Only the runner's platform is built here; the multi-platform build
+      # happens on release, where it's worth the QEMU emulation time
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: calkit/resources/devcontainer
+          load: true
+          tags: calkit/devcontainer:pr
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Smoke test image
+        run: |
+          docker run --rm calkit/devcontainer:pr bash -c '
+            set -euxo pipefail
+            calkit --version
+            uv --version
+            pixi --version
+            conda --version
+            for script in post-create.sh post-start.sh update-content.sh \
+                check-envs.sh; do
+              bash -n "$INIT_SCRIPTS_DIR/$script"
+            done
+          '

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,8 @@ jobs:
         id: version
         run: |
           version="${{ github.event.release.tag_name }}"
+          # Both PyPI and the image tag want the bare version, without the
+          # `v` the Git tag carries
           echo "version=${version#v}" >> "$GITHUB_OUTPUT"
       # PyPI's index can lag the upload by a bit, and the build fails outright
       # if the pinned version isn't resolvable yet

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,3 +70,69 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+  publish-devcontainer:
+    name: Publish the dev container image 🐳
+    # The image installs the version being released from PyPI, so it can't
+    # be built until that version is actually there
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      IMAGE: ghcr.io/calkit/devcontainer
+    steps:
+      - uses: actions/checkout@v7
+      - name: Determine version
+        id: version
+        run: |
+          version="${{ github.event.release.tag_name }}"
+          echo "version=${version#v}" >> "$GITHUB_OUTPUT"
+      # PyPI's index can lag the upload by a bit, and the build fails outright
+      # if the pinned version isn't resolvable yet
+      - name: Wait for the release on PyPI
+        run: |
+          url="https://pypi.org/pypi/calkit-python/${{ steps.version.outputs.version }}/json"
+          for i in $(seq 1 30); do
+            if curl -sfo /dev/null "$url"; then
+              echo "Found calkit-python ${{ steps.version.outputs.version }}"
+              exit 0
+            fi
+            echo "Not on PyPI yet; retrying in 20s ($i/30)"
+            sleep 20
+          done
+          echo "calkit-python ${{ steps.version.outputs.version }} never appeared on PyPI"
+          exit 1
+      - name: Log in to the container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: calkit/resources/devcontainer
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: CALKIT_VERSION=${{ steps.version.outputs.version }}
+          tags: |
+            ${{ env.IMAGE }}:latest
+            ${{ env.IMAGE }}:${{ steps.version.outputs.version }}
+      # An unforgeable statement about where and how the image was built,
+      # which increases supply chain security for anyone who consumes it
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ${{ env.IMAGE }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/test-run-action.yml
+++ b/.github/workflows/test-run-action.yml
@@ -1,0 +1,85 @@
+name: Test run action
+
+# Saving/pulling is disabled below, so no Calkit/DVC token (and no OIDC) is
+# needed and the default read-only token is sufficient
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "actions/**"
+      # The action is a wrapper around CLI commands, and reads
+      # `calkit list environments` output to decide what to install, so a
+      # change to the package can break it
+      - "calkit/**"
+      - "!calkit/tests/**"
+      - ".github/workflows/test-run-action.yml"
+  workflow_dispatch:
+
+jobs:
+  run-examples:
+    name: ${{ matrix.example.repo }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each entry clones a real Calkit example project and runs a single
+        # lightweight stage so the action's environment setup is exercised
+        # without building the heavy `tex` (texlive/texlive Docker) env that
+        # these projects use for their paper-build stages. `target` must be a
+        # stage whose environment is the one we want to verify got installed.
+        # To cover another kind, add an example repo + a cheap target here.
+        example:
+          - repo: example-basic
+            target: collect-data # uses the `py` (uv-venv) environment
+            verify: uv --version
+          - repo: example-julia
+            target: run-script # uses the `main` (julia) environment
+            verify: julia --version
+    steps:
+      # The composite action's steps run in $GITHUB_WORKSPACE, and it reads
+      # ./calkit.yaml from there, so the example project must be the workspace
+      # root. The workspace is empty at job start, so cloning into "." works;
+      # this repo then gets checked out into a subdirectory and the action
+      # referenced locally via `uses: ./_calkit/actions/run`.
+      - name: Clone example project
+        run: git clone --depth 1 "https://github.com/calkit/${{ matrix.example.repo }}.git" .
+
+      # Unshallow, since hatch-vcs derives the version from the release tags
+      - name: Check out this repo
+        uses: actions/checkout@v7
+        with:
+          path: _calkit
+          fetch-depth: 0
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+
+      # The action skips installing Calkit when it's already on PATH, so
+      # installing the working tree here is what makes this test cover the
+      # CLI being changed rather than the last release
+      - name: Install Calkit from the working tree
+        env:
+          # Building the JupyterLab extension needs Node and isn't used here
+          HATCH_BUILD_NO_HOOKS: "true"
+        run: |
+          uv tool install ./_calkit
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Verify the working tree's Calkit is what the action will use
+        run: |
+          which calkit
+          calkit --version
+
+      - name: Run Calkit action
+        uses: ./_calkit/actions/run
+        with:
+          save: "false"
+          pull_dvc: "false"
+          cache_dvc: "false"
+          run_args: ${{ matrix.example.target }}
+
+      - name: Verify expected tooling was installed
+        run: ${{ matrix.example.verify }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,9 @@
 - The JupyterLab extension lives in `src`
 - The VS Code extension lives in `vscode-ext`
 - The Chrome extension lives in `browser-ext`
+- Config Calkit installs into projects, e.g., the dev container and VS Code
+  configs, lives in `calkit/resources`; see the README there before editing,
+  since the dev container spec is generated
 
 ## Working
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,10 @@
 - The JupyterLab extension lives in `src`
 - The VS Code extension lives in `vscode-ext`
 - The Chrome extension lives in `browser-ext`
-- Config Calkit installs into projects, e.g., the dev container and VS Code
-  configs, lives in `calkit/resources`; see the README there before editing,
-  since the dev container spec is generated
+- GitHub Actions live in `actions`, e.g., `calkit/calkit/actions/run`
+- Config Calkit installs into projects, e.g., the dev container, VS Code, and
+  GitHub Actions configs, lives in `calkit/resources`; see the README there
+  before editing, since some of those files are generated
 
 ## Working
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ frontend-client: ## Regenerate the hub frontend's API client.
 	@$(MAKE) -C hub/frontend client
 
 .PHONY: format
-format: sync-docs ## Automatically format files.
+format: sync-docs sync-resources ## Automatically format files.
 	@echo "🚀 Linting code with pre-commit"
 	@uv run pre-commit run -a
 
@@ -50,6 +50,19 @@ sync-docs: ## Sync documentation content from docs/*.md into README.md.
 	@uv run python scripts/generate-docs-references.py
 	@echo "🚀 Syncing documentation"
 	@uv run python scripts/sync-docs.py
+
+.PHONY: sync-resources
+sync-resources: ## Regenerate the dev container spec from the VS Code config.
+	@echo "🚀 Syncing project resources"
+	@uv run python scripts/sync-resources.py
+
+.PHONY: devcontainer-image
+devcontainer-image: ## Build the dev container image and smoke test it.
+	@echo "🚀 Building the dev container image"
+	@docker build -t calkit/devcontainer:dev calkit/resources/devcontainer
+	@echo "🚀 Smoke testing the dev container image"
+	@docker run --rm calkit/devcontainer:dev bash -c \
+		"calkit --version && uv --version && pixi --version && conda --version"
 
 .PHONY: docs
 docs: sync-docs ## Build and serve the documentation.

--- a/actions/run/README.md
+++ b/actions/run/README.md
@@ -111,4 +111,5 @@ This action was previously published from
 [`calkit/run-action`](https://github.com/calkit/run-action), which is no
 longer maintained.
 Workflows referencing `calkit/run-action@v2` still work, but should be
-updated to `calkit/calkit/actions/run@<version>`.
+updated to `calkit/calkit/actions/run@<version>`, which
+`calkit update github-actions` will do in place.

--- a/actions/run/README.md
+++ b/actions/run/README.md
@@ -1,0 +1,114 @@
+# Calkit run GitHub Action
+
+A GitHub Action to run a Calkit project's pipeline and optionally save results
+(commit and push) to Git and DVC.
+
+The action lives in the Calkit repo because it's a thin wrapper around a
+sequence of CLI commands, and it reads `calkit list environments` output to
+decide what tooling to install.
+Keeping it here means a change to either is tested against the other before
+release.
+
+## Usage
+
+Reference the action by a Calkit release tag:
+
+```yaml
+- uses: calkit/calkit/actions/run@v0.43.0
+```
+
+The easiest way to add it to a project is:
+
+```sh
+calkit update github-actions
+```
+
+which writes the workflow below to `.github/workflows/run-calkit.yml`,
+pinned to the version of Calkit that wrote it.
+Rerun it after upgrading Calkit to move the pin.
+
+<!-- Do not edit the snippet below since it is automatically populated -->
+<!-- snippet:example.yml:start -->
+
+```yaml
+name: Run pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+# Make sure we only ever run one per branch so we don't have issues pushing
+# after running the pipeline
+concurrency:
+  group: calkit-run-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  main:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For PRs, checkout the head ref to avoid detached HEAD
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure Git credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      # This action automatically runs necessary setup steps based on environments
+      - name: Run Calkit
+        uses: calkit/calkit/actions/run@main
+```
+
+<!-- snippet:example.yml:end -->
+
+Note the permissions, concurrency, and checkout options.
+The action detects required environment kinds from `calkit.yaml` and sets up
+needed tooling (for example Calkit via `uv`, Julia, Pixi, Conda, R, MATLAB,
+and Docker Buildx) before running.
+
+## Configuration
+
+If simply running the pipeline is desired, the `save` option can be set to
+`false`.
+Additionally, caching DVC data can be disabled with `cache_dvc: false`.
+When caching is enabled, the action saves DVC cache entries using the current
+branch name plus the current commit SHA.
+The restore step first looks for the
+most recent cache for the current branch and then falls back to the default
+branch cache if the current branch cache doesn't exist yet.
+
+## System dependencies
+
+System dependencies like `uv`, `pixi`, `conda`, `juliaup` will be installed
+automatically if missing, and if the project has an environment with the
+corresponding kind.
+If you'd like control over which versions are used, you can add setup steps
+before the Calkit Action, and Calkit will detect and skip installation.
+
+## Development
+
+`example.yml` is the source for both the snippet above and the copy bundled
+into the Python package at `calkit/resources/github-actions`.
+After editing it, run `make sync-resources`.
+
+CI runs the action against real example projects on every pull request that
+touches this directory, with Calkit installed from the working tree first, so
+the action exercises the CLI being changed rather than the last release.
+
+## Previous home
+
+This action was previously published from
+[`calkit/run-action`](https://github.com/calkit/run-action), which is no
+longer maintained.
+Workflows referencing `calkit/run-action@v2` still work, but should be
+updated to `calkit/calkit/actions/run@<version>`.

--- a/actions/run/action.yml
+++ b/actions/run/action.yml
@@ -1,0 +1,349 @@
+name: Run Calkit
+description: >
+  Run a Calkit project pipeline and optionally commit and push results to Git
+  and DVC remotes.
+branding:
+  icon: arrow-right
+  color: green
+inputs:
+  save:
+    description: Whether or not to save (commit and push) results to Git and DVC remotes.
+    default: "true"
+  dvc_token:
+    description:
+      DVC token for pushing results. If not provided, will be obtained
+      via GitHub OIDC.
+    required: false
+  pull_dvc:
+    description: Whether or not to pull DVC data before running.
+    required: false
+    default: "true"
+  cache_dvc:
+    description: Whether or not to cache DVC data.
+    required: false
+    default: "true"
+  run_args:
+    description: Arguments passed to calkit run command.
+    required: false
+    default: ""
+outputs: {}
+runs:
+  using: composite
+  steps:
+    - name: Check for uv and Calkit
+      id: tools
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v uv >/dev/null 2>&1; then
+          echo "uv_missing=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "uv_missing=true" >> "$GITHUB_OUTPUT"
+        fi
+        if command -v calkit >/dev/null 2>&1; then
+          echo "calkit_missing=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "calkit_missing=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    # uv is only needed up front to install Calkit; uv-venv projects that
+    # need uv but already have Calkit are handled by the uv step after
+    # detection.
+    - name: Setup uv
+      if: ${{ steps.tools.outputs.uv_missing == 'true' && steps.tools.outputs.calkit_missing == 'true' }}
+      uses: astral-sh/setup-uv@v5
+
+    - name: Install Calkit
+      if: ${{ steps.tools.outputs.calkit_missing == 'true' }}
+      shell: bash
+      run: |
+        uv tool install calkit-python
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+    - name: Detect setup requirements
+      id: detect
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        # Let Calkit parse its own config so we only look at the
+        # `environments` section (a real YAML parse that also resolves
+        # includes), rather than grepping every `kind:` in the file --
+        # pipeline stages, dependencies, datasets, etc. all use `kind:` too.
+        kinds=$(calkit list environments 2>/dev/null \
+          | grep -E '^[[:space:]]+kind:' \
+          | sed -E 's/^[[:space:]]+kind:[[:space:]]*//; s/[[:space:]]+#.*$//' \
+          | tr -d "\"'" | sort -u || true)
+        echo "Detected environment kinds: $(echo "$kinds" | paste -sd, -)"
+
+        has_kind() {
+          printf '%s\n' "$kinds" | grep -qx "$1"
+        }
+
+        if command -v python >/dev/null 2>&1 || command -v python3 >/dev/null 2>&1; then
+          python_missing=false
+        else
+          python_missing=true
+        fi
+
+        if command -v uv >/dev/null 2>&1; then
+          uv_missing=false
+        else
+          uv_missing=true
+        fi
+
+        if command -v conda >/dev/null 2>&1; then
+          conda_missing=false
+        else
+          conda_missing=true
+        fi
+
+        if command -v pixi >/dev/null 2>&1; then
+          pixi_missing=false
+        else
+          pixi_missing=true
+        fi
+
+        # Calkit manages Julia versions via juliaup (e.g. `juliaup add
+        # 1.11.7` for a `julia: "1.11.7"` environment), so juliaup -- not a
+        # fixed Julia -- is what must be present. We deliberately gate only on
+        # juliaup and ignore any plain `julia` on the runner: hosted runner
+        # images ship a pinned Julia that usually won't match the project's
+        # required version, and without juliaup Calkit can't install the right
+        # one. Users who manage Julia themselves should install juliaup, which
+        # this then detects and leaves alone.
+        if command -v juliaup >/dev/null 2>&1; then
+          juliaup_missing=false
+        else
+          juliaup_missing=true
+        fi
+
+        if command -v Rscript >/dev/null 2>&1 || command -v R >/dev/null 2>&1; then
+          r_missing=false
+        else
+          r_missing=true
+        fi
+
+        if command -v matlab >/dev/null 2>&1; then
+          matlab_missing=false
+        else
+          matlab_missing=true
+        fi
+
+        if command -v docker >/dev/null 2>&1 && docker buildx version >/dev/null 2>&1; then
+          docker_buildx_missing=false
+        else
+          docker_buildx_missing=true
+        fi
+
+        needs_python=false
+        needs_uv=false
+        needs_conda=false
+        needs_pixi=false
+        needs_julia=false
+        needs_r=false
+        needs_matlab=false
+        needs_docker=false
+        docker_cli_missing=false
+        unsupported_kinds=""
+
+        if has_kind "uv-venv" || has_kind "venv" || has_kind "uv"; then
+          if [ "$python_missing" = true ]; then
+            needs_python=true
+          fi
+        fi
+        # uv is installed up front to install Calkit, so it is normally
+        # already present here; this covers the case where Calkit was
+        # pre-installed (so we skipped the initial uv setup) but uv is not.
+        if has_kind "uv-venv" || has_kind "uv"; then
+          if [ "$uv_missing" = true ]; then
+            needs_uv=true
+          fi
+        fi
+        if has_kind "conda"; then
+          if [ "$conda_missing" = true ]; then
+            needs_conda=true
+          fi
+          if [ "$python_missing" = true ]; then
+            needs_python=true
+          fi
+        fi
+        if has_kind "pixi"; then
+          if [ "$pixi_missing" = true ]; then
+            needs_pixi=true
+          fi
+        fi
+        if has_kind "julia"; then
+          if [ "$juliaup_missing" = true ]; then
+            needs_julia=true
+          fi
+        fi
+        if has_kind "renv"; then
+          if [ "$r_missing" = true ]; then
+            needs_r=true
+          fi
+        fi
+        if has_kind "matlab"; then
+          if [ "$matlab_missing" = true ]; then
+            needs_matlab=true
+          fi
+        fi
+        if has_kind "docker"; then
+          if command -v docker >/dev/null 2>&1; then
+            if [ "$docker_buildx_missing" = true ]; then
+              needs_docker=true
+            fi
+          else
+            docker_cli_missing=true
+          fi
+        fi
+
+        # These kinds do not have a direct setup action in this composite action.
+        if has_kind "ssh"; then unsupported_kinds="${unsupported_kinds}ssh,"; fi
+        if has_kind "slurm"; then unsupported_kinds="${unsupported_kinds}slurm,"; fi
+        if has_kind "pbs"; then unsupported_kinds="${unsupported_kinds}pbs,"; fi
+        if has_kind "nix"; then unsupported_kinds="${unsupported_kinds}nix,"; fi
+        unsupported_kinds="${unsupported_kinds%,}"
+
+        echo "needs_python=${needs_python}" >> "$GITHUB_OUTPUT"
+        echo "needs_uv=${needs_uv}" >> "$GITHUB_OUTPUT"
+        echo "needs_conda=${needs_conda}" >> "$GITHUB_OUTPUT"
+        echo "needs_pixi=${needs_pixi}" >> "$GITHUB_OUTPUT"
+        echo "needs_julia=${needs_julia}" >> "$GITHUB_OUTPUT"
+        echo "needs_r=${needs_r}" >> "$GITHUB_OUTPUT"
+        echo "needs_matlab=${needs_matlab}" >> "$GITHUB_OUTPUT"
+        echo "needs_docker=${needs_docker}" >> "$GITHUB_OUTPUT"
+        echo "docker_cli_missing=${docker_cli_missing}" >> "$GITHUB_OUTPUT"
+        echo "unsupported_kinds=${unsupported_kinds}" >> "$GITHUB_OUTPUT"
+
+    - name: Setup uv for uv and uv-venv environments
+      if: ${{ steps.detect.outputs.needs_uv == 'true' }}
+      uses: astral-sh/setup-uv@v5
+
+    - name: Setup Python
+      if: ${{ steps.detect.outputs.needs_python == 'true' }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+
+    - name: Setup Miniconda
+      if: ${{ steps.detect.outputs.needs_conda == 'true' }}
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-activate-base: true
+        conda-remove-defaults: true
+
+    - name: Setup Pixi
+      if: ${{ steps.detect.outputs.needs_pixi == 'true' }}
+      uses: prefix-dev/setup-pixi@v0.9.6
+      with:
+        run-install: false
+
+    # Install juliaup (not a fixed Julia) so Calkit can install and select
+    # the exact Julia version(s) declared in each environment via
+    # `juliaup add`. The channel here is just a default bootstrap install.
+    - name: Setup juliaup
+      if: ${{ steps.detect.outputs.needs_julia == 'true' }}
+      uses: julia-actions/install-juliaup@v2
+      with:
+        channel: "1"
+
+    - name: Setup R
+      if: ${{ steps.detect.outputs.needs_r == 'true' }}
+      uses: r-lib/actions/setup-r@v2
+
+    - name: Setup MATLAB
+      if: ${{ steps.detect.outputs.needs_matlab == 'true' }}
+      uses: matlab-actions/setup-matlab@v2
+
+    - name: Setup Docker Buildx
+      if: ${{ steps.detect.outputs.needs_docker == 'true' }}
+      uses: docker/setup-buildx-action@v3
+
+    - name: Report unsupported environment kinds
+      if: ${{ steps.detect.outputs.unsupported_kinds != '' }}
+      shell: bash
+      run: |
+        echo "::notice::Detected environment kinds without explicit setup action: ${{ steps.detect.outputs.unsupported_kinds }}"
+
+    - name: Report missing Docker CLI for docker environments
+      if: ${{ steps.detect.outputs.docker_cli_missing == 'true' }}
+      shell: bash
+      run: |
+        echo "::notice::Detected kind 'docker' in calkit.yaml, but Docker CLI is not available on this runner. Install Docker on the runner to use docker environments."
+
+    - name: Restore DVC cache for current branch
+      if: ${{ inputs.cache_dvc == 'true' }}
+      id: cache-dvc-restore
+      uses: actions/cache/restore@v5
+      with:
+        path: .dvc/cache
+        key: >-
+          ${{ runner.os }}-dvc-cache-${{ github.head_ref || github.ref_name }}-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-dvc-cache-${{ github.head_ref || github.ref_name }}-
+          ${{ runner.os }}-dvc-cache-${{ github.event.repository.default_branch }}-
+
+    - name: Get GitHub OIDC token
+      if: ${{ !inputs.dvc_token && (inputs.save == 'true' || inputs.pull_dvc ==
+        'true') }}
+      id: get-oidc-token
+      shell: bash
+      run: |
+        OIDC_TOKEN=$(curl -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=calkit.io" -s | jq -r '.value')
+        if [ -z "$OIDC_TOKEN" ] || [ "$OIDC_TOKEN" == "null" ]; then
+          echo "Failed to obtain OIDC token"
+          exit 1
+        fi
+        echo "::add-mask::$OIDC_TOKEN"
+        echo "oidc-token=$OIDC_TOKEN" >> $GITHUB_OUTPUT
+
+    - name: Exchange OIDC token for Calkit token
+      if: ${{ !inputs.dvc_token && (inputs.save == 'true' || inputs.pull_dvc ==
+        'true') }}
+      id: get-calkit-token
+      shell: bash
+      run: |
+        CALKIT_TOKEN=$(curl -X POST https://api.calkit.io/login/github-oidc \
+          -H "Authorization: Bearer ${{ steps.get-oidc-token.outputs.oidc-token }}" \
+          -s | jq -r '.access_token')
+        if [ -z "$CALKIT_TOKEN" ] || [ "$CALKIT_TOKEN" == "null" ]; then
+          echo "Failed to obtain Calkit token"
+          exit 1
+        fi
+        echo "::add-mask::$CALKIT_TOKEN"
+        echo "calkit-token=$CALKIT_TOKEN" >> $GITHUB_OUTPUT
+
+    - run: calkit config remote-auth
+      if: ${{ inputs.save == 'true' || inputs.pull_dvc == 'true' }}
+      shell: bash
+      env:
+        CALKIT_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+        CALKIT_DVC_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+
+    - run: calkit dvc pull
+      if: ${{ inputs.pull_dvc == 'true' }}
+      shell: bash
+      continue-on-error: true
+      env:
+        CALKIT_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+        CALKIT_DVC_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+
+    - run: calkit run ${{ inputs.run_args }}
+      shell: bash
+
+    - run: calkit save -am "Run pipeline"
+      if: ${{ inputs.save == 'true' }}
+      shell: bash
+      env:
+        CALKIT_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+        CALKIT_DVC_TOKEN: ${{ inputs.dvc_token || steps.get-calkit-token.outputs.calkit-token }}
+
+    - name: Save DVC cache
+      if: ${{ inputs.cache_dvc == 'true' }}
+      id: cache-dvc-save
+      uses: actions/cache/save@v5
+      with:
+        path: .dvc/cache
+        key: >-
+          ${{ runner.os }}-dvc-cache-${{ github.head_ref || github.ref_name }}-${{ github.sha }}

--- a/actions/run/example.yml
+++ b/actions/run/example.yml
@@ -1,0 +1,36 @@
+name: Run pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+# Make sure we only ever run one per branch so we don't have issues pushing
+# after running the pipeline
+concurrency:
+  group: calkit-run-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  main:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For PRs, checkout the head ref to avoid detached HEAD
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure Git credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      # This action automatically runs necessary setup steps based on environments
+      - name: Run Calkit
+        uses: calkit/calkit/actions/run@main

--- a/calkit/__init__.py
+++ b/calkit/__init__.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
         overleaf,
         pipeline,
         releases,
+        resources,
         server,
         templates,
     )
@@ -61,6 +62,7 @@ _SUBMODULES = {
     "github",
     "invenio",
     "releases",
+    "resources",
     "licenses",
     "overleaf",
     "julia",

--- a/calkit/cli/update.py
+++ b/calkit/cli/update.py
@@ -46,7 +46,7 @@ def update_devcontainer(
     os.makedirs(out_dir, exist_ok=True)
     out_fpath = os.path.join(out_dir, "devcontainer.json")
     typer.echo(f"Writing to {out_fpath}")
-    with open(out_fpath, "w") as f:
+    with open(out_fpath, "w", encoding="utf-8") as f:
         f.write(
             calkit_resources.read_text(
                 "devcontainer", calkit_resources.DEVCONTAINER_FNAME
@@ -357,7 +357,7 @@ def update_vscode_config(
     for fname in calkit_resources.VSCODE_FNAMES:
         out_fpath = os.path.join(out_dir, fname)
         typer.echo(f"Writing to {out_fpath}")
-        with open(out_fpath, "w") as f:
+        with open(out_fpath, "w", encoding="utf-8") as f:
             f.write(calkit_resources.read_text("vscode", fname))
         repo.git.add(os.path.join(".vscode", fname))
     if not no_commit and repo.git.diff(["--staged", "--", ".vscode"]):
@@ -386,25 +386,41 @@ def update_github_actions(
 ):
     """Update a project's GitHub Actions to match this version of Calkit's
     recommendations.
+
+    An existing workflow that runs the Calkit action is updated in place,
+    pinning the action to this version of Calkit, so this is safe to rerun
+    after upgrading.
     """
     from calkit import resources as calkit_resources
 
-    # First look for any existing workflows that run Calkit to use as the
-    # output file name
+    # First look for an existing workflow that runs the Calkit action, so
+    # rerunning this updates a project's workflow instead of writing a
+    # second one beside it
     fname_out = "run-calkit.yml"
+    txt_out = None
     out_dir = os.path.join(wdir or ".", ".github", "workflows")
     os.makedirs(out_dir, exist_ok=True)
-    for fname in os.listdir(out_dir):
+    for fname in sorted(os.listdir(out_dir)):
         if fname.endswith(".yaml") or fname.endswith(".yml"):
             fpath = os.path.join(out_dir, fname)
-            with open(fpath) as f:
-                if "calkit" in f.read().lower():
-                    fname_out = fname
-                    break
+            with open(fpath, encoding="utf-8") as f:
+                txt = f.read()
+            if calkit_resources.uses_run_action(txt):
+                fname_out = fname
+                # A workflow that's still the example gets replaced outright,
+                # picking up any other improvements to it, but one that's been
+                # customized only has its action ref updated
+                if not calkit_resources.is_default_github_actions_workflow(
+                    txt
+                ):
+                    txt_out = calkit_resources.set_action_ref(txt)
+                break
+    if txt_out is None:
+        txt_out = calkit_resources.render_github_actions_workflow()
     out_fpath = os.path.join(out_dir, fname_out)
     typer.echo(f"Writing to {out_fpath}")
-    with open(out_fpath, "w") as f:
-        f.write(calkit_resources.render_github_actions_workflow())
+    with open(out_fpath, "w", encoding="utf-8") as f:
+        f.write(txt_out)
     if not no_commit:
         rel_path = os.path.join(".github", "workflows", fname_out)
         repo = calkit.git.get_repo(wdir)

--- a/calkit/cli/update.py
+++ b/calkit/cli/update.py
@@ -37,21 +37,21 @@ def update_devcontainer(
         ),
     ] = False,
 ):
-    """Update a project's devcontainer to match the latest Calkit spec."""
-    import requests
+    """Update a project's devcontainer to match this version of Calkit's
+    spec.
+    """
+    from calkit import resources as calkit_resources
 
-    url = (
-        "https://raw.githubusercontent.com/calkit/devcontainer/"
-        "refs/heads/main/devcontainer.json"
-    )
-    typer.echo(f"Downloading {url}")
-    resp = requests.get(url)
     out_dir = os.path.join(wdir or ".", ".devcontainer")
     os.makedirs(out_dir, exist_ok=True)
     out_fpath = os.path.join(out_dir, "devcontainer.json")
     typer.echo(f"Writing to {out_fpath}")
     with open(out_fpath, "w") as f:
-        f.write(resp.text)
+        f.write(
+            calkit_resources.read_text(
+                "devcontainer", calkit_resources.DEVCONTAINER_FNAME
+            )
+        )
     if not no_commit:
         repo = calkit.git.get_repo(wdir)
         rel_path = os.path.join(".devcontainer", "devcontainer.json")
@@ -346,27 +346,19 @@ def update_vscode_config(
         ),
     ] = False,
 ):
-    """Update a project's VS Code config to match the latest Calkit
+    """Update a project's VS Code config to match this version of Calkit's
     recommendations.
     """
-    import requests
+    from calkit import resources as calkit_resources
 
     out_dir = os.path.join(wdir or ".", ".vscode")
     os.makedirs(out_dir, exist_ok=True)
     repo = calkit.git.get_repo(wdir)
-    for fname in ["settings.json", "extensions.json"]:
-        url = (
-            f"https://raw.githubusercontent.com/calkit/vscode-config/"
-            f"refs/heads/main/{fname}"
-        )
-        typer.echo(f"Downloading {url}")
-        resp = requests.get(url)
-        out_dir = os.path.join(wdir or ".", ".vscode")
-        os.makedirs(out_dir, exist_ok=True)
+    for fname in calkit_resources.VSCODE_FNAMES:
         out_fpath = os.path.join(out_dir, fname)
         typer.echo(f"Writing to {out_fpath}")
         with open(out_fpath, "w") as f:
-            f.write(resp.text)
+            f.write(calkit_resources.read_text("vscode", fname))
         repo.git.add(os.path.join(".vscode", fname))
     if not no_commit and repo.git.diff(["--staged", "--", ".vscode"]):
         repo.git.commit([".vscode", "-m", "Update VS Code config"])

--- a/calkit/cli/update.py
+++ b/calkit/cli/update.py
@@ -384,10 +384,10 @@ def update_github_actions(
         ),
     ] = False,
 ):
-    """Update a project's GitHub Actions to match the latest Calkit
+    """Update a project's GitHub Actions to match this version of Calkit's
     recommendations.
     """
-    import requests
+    from calkit import resources as calkit_resources
 
     # First look for any existing workflows that run Calkit to use as the
     # output file name
@@ -401,16 +401,10 @@ def update_github_actions(
                 if "calkit" in f.read().lower():
                     fname_out = fname
                     break
-    url = (
-        "https://raw.githubusercontent.com/calkit/run-action/refs/heads/main"
-        "/example.yml"
-    )
-    typer.echo(f"Downloading {url}")
-    resp = requests.get(url)
     out_fpath = os.path.join(out_dir, fname_out)
     typer.echo(f"Writing to {out_fpath}")
     with open(out_fpath, "w") as f:
-        f.write(resp.text)
+        f.write(calkit_resources.render_github_actions_workflow())
     if not no_commit:
         rel_path = os.path.join(".github", "workflows", fname_out)
         repo = calkit.git.get_repo(wdir)

--- a/calkit/resources/README.md
+++ b/calkit/resources/README.md
@@ -6,13 +6,21 @@ These ship with the Python package, like the templates in
 offline and always match the installed version of Calkit.
 See [`__init__.py`](__init__.py) for how to read them.
 
-| Resource                       | Command                       |
-| ------------------------------ | ----------------------------- |
-| [`devcontainer`](devcontainer) | `calkit update devcontainer`  |
-| [`vscode`](vscode)             | `calkit update vscode-config` |
+| Resource                             | Command                        |
+| ------------------------------------ | ------------------------------ |
+| [`devcontainer`](devcontainer)       | `calkit update devcontainer`   |
+| [`vscode`](vscode)                   | `calkit update vscode-config`  |
+| [`github-actions`](github-actions)   | `calkit update github-actions` |
 
-The VS Code settings and extension recommendations in
-[`vscode`](vscode) are the single source of truth.
-The dev container spec's `customizations.vscode` section is generated from
-them, so run `make sync-resources` (or `make format`) after editing either.
+Two of these are generated, so edit the source rather than the copy here,
+then run `make sync-resources` (or `make format`).
 `calkit/tests/test_resources.py` fails if they're out of sync.
+
+| Generated                            | Source                                       |
+| ------------------------------------ | -------------------------------------------- |
+| `devcontainer/devcontainer.json`     | `devcontainer/base.json` plus [`vscode`](vscode) |
+| `github-actions/example.yml`         | [`actions/run/example.yml`](../../actions/run/example.yml), which sits next to the action it calls |
+
+The VS Code settings and extension recommendations are the single source of
+truth for the editor setup, so a project gets the same one whether or not
+it's opened in a container.

--- a/calkit/resources/README.md
+++ b/calkit/resources/README.md
@@ -1,0 +1,18 @@
+# Calkit project resources
+
+Configuration Calkit copies into projects.
+These ship with the Python package, like the templates in
+[`../templates`](../templates), so the commands that install them work
+offline and always match the installed version of Calkit.
+See [`__init__.py`](__init__.py) for how to read them.
+
+| Resource                       | Command                       |
+| ------------------------------ | ----------------------------- |
+| [`devcontainer`](devcontainer) | `calkit update devcontainer`  |
+| [`vscode`](vscode)             | `calkit update vscode-config` |
+
+The VS Code settings and extension recommendations in
+[`vscode`](vscode) are the single source of truth.
+The dev container spec's `customizations.vscode` section is generated from
+them, so run `make sync-resources` (or `make format`) after editing either.
+`calkit/tests/test_resources.py` fails if they're out of sync.

--- a/calkit/resources/__init__.py
+++ b/calkit/resources/__init__.py
@@ -19,9 +19,19 @@ import re
 DEVCONTAINER_FNAME = "devcontainer.json"
 VSCODE_FNAMES = ["settings.json", "extensions.json"]
 GITHUB_ACTIONS_FNAME = "example.yml"
+ACTION_PATH = "calkit/calkit/actions/run"
 # The ref the example workflow ships with, which gets pinned to a released
 # version of Calkit when there is one to pin to
-ACTION_REF = "calkit/calkit/actions/run@main"
+ACTION_REF = f"{ACTION_PATH}@main"
+# The action used to live in its own repo, and workflows written before it
+# moved still point there
+LEGACY_ACTION_PATHS = ["calkit/run-action"]
+ACTION_USES_PATTERN = re.compile(
+    r"(?m)^(?P<prefix>\s*(?:-\s+)?uses:\s*)(?P<quote>['\"]?)"
+    + r"(?:"
+    + "|".join(re.escape(p) for p in [ACTION_PATH] + LEGACY_ACTION_PATHS)
+    + r")@[^\s'\"#]+(?P=quote)"
+)
 
 
 def get_dir() -> str:
@@ -50,29 +60,32 @@ def render_devcontainer_spec() -> dict:
     it's opened in a container.
     """
     spec = load_json("devcontainer", "base.json")
+    base = spec.setdefault("customizations", {}).get("vscode", {})
     settings = load_json("vscode", "settings.json")
     # Container-only settings win, since they exist to override how things
     # work inside the container
-    settings |= (
-        spec.get("customizations", {}).get("vscode", {}).get("settings", {})
-    )
-    extensions = load_json("vscode", "extensions.json")["recommendations"]
-    spec.setdefault("customizations", {})["vscode"] = {
-        "extensions": extensions,
+    settings |= base.get("settings", {})
+    vscode = {
+        "extensions": load_json("vscode", "extensions.json")[
+            "recommendations"
+        ],
         "settings": settings,
     }
+    # Anything else the base customizes, e.g., a future `snippets` key, is
+    # kept as-is
+    for key, value in base.items():
+        vscode.setdefault(key, value)
+    spec["customizations"]["vscode"] = vscode
     return spec
 
 
-def render_github_actions_workflow(version: str | None = None) -> str:
-    """Return the example workflow, pinning the action to a Calkit version.
+def get_action_ref(version: str | None = None) -> str:
+    """Return the run action ref matching a version of Calkit.
 
     The action lives in this repo at ``actions/run``, so its refs are
     Calkit's own release tags, and a project ends up pinned to the version
-    of Calkit that wrote its workflow. Rerunning ``calkit update github-actions`` after
-    upgrading moves the pin.
+    of Calkit that wrote its workflow.
     """
-    txt = read_text("github-actions", GITHUB_ACTIONS_FNAME)
     if version is None:
         import calkit
 
@@ -80,5 +93,52 @@ def render_github_actions_workflow(version: str | None = None) -> str:
     # Development installs report versions like 0.42.2.dev0+g21c9bb93, which
     # isn't a tag anyone can reference, so those stay on main
     if re.fullmatch(r"\d+\.\d+\.\d+", version):
-        txt = txt.replace(ACTION_REF, f"calkit/calkit/actions/run@v{version}")
-    return txt
+        return f"{ACTION_PATH}@v{version}"
+    return ACTION_REF
+
+
+def uses_run_action(workflow_txt: str) -> bool:
+    """Return whether a workflow runs the Calkit action, at any ref."""
+    return ACTION_USES_PATTERN.search(workflow_txt) is not None
+
+
+def set_action_ref(workflow_txt: str, version: str | None = None) -> str:
+    """Point a workflow's Calkit action refs at a version of Calkit.
+
+    Only the ``uses`` lines are touched, so a project that has customized
+    its workflow keeps those customizations. Refs to the action's previous
+    home get migrated in the process.
+    """
+    ref = get_action_ref(version)
+    return ACTION_USES_PATTERN.sub(
+        lambda m: (
+            m.group("prefix") + m.group("quote") + ref + m.group("quote")
+        ),
+        workflow_txt,
+    )
+
+
+def render_github_actions_workflow(version: str | None = None) -> str:
+    """Return the example workflow, pinning the action to a Calkit version."""
+    return set_action_ref(
+        read_text("github-actions", GITHUB_ACTIONS_FNAME), version=version
+    )
+
+
+def is_default_github_actions_workflow(workflow_txt: str) -> bool:
+    """Return whether a workflow is the example, unmodified.
+
+    Its action ref is ignored, since that gets pinned to whichever version
+    of Calkit wrote the workflow, as are line endings, which Git may have
+    translated on checkout.
+    """
+
+    def normalize(txt: str) -> str:
+        txt = ACTION_USES_PATTERN.sub(
+            lambda m: m.group("prefix") + ACTION_REF, txt
+        )
+        return txt.replace("\r\n", "\n").strip()
+
+    return normalize(workflow_txt) == normalize(
+        read_text("github-actions", GITHUB_ACTIONS_FNAME)
+    )

--- a/calkit/resources/__init__.py
+++ b/calkit/resources/__init__.py
@@ -1,0 +1,59 @@
+"""Bundled project resources.
+
+These are the dev container and VS Code configs that get copied into projects
+by ``calkit update devcontainer`` and ``calkit update vscode-config``. They
+ship with the package, so installing them into a project never requires a
+download, and they always match the installed version of Calkit.
+
+The dev container spec's VS Code customizations are generated from the shared
+VS Code config, which keeps the two in sync. Run ``make sync-resources`` after
+editing ``vscode/*.json`` or ``devcontainer/base.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+DEVCONTAINER_FNAME = "devcontainer.json"
+VSCODE_FNAMES = ["settings.json", "extensions.json"]
+
+
+def get_dir() -> str:
+    """Return the directory containing the bundled resources."""
+    return os.path.dirname(os.path.abspath(__file__))
+
+
+def read_text(*relpath: str) -> str:
+    """Read a bundled resource file as text."""
+    with open(os.path.join(get_dir(), *relpath), encoding="utf-8") as f:
+        return f.read()
+
+
+def load_json(*relpath: str) -> dict:
+    """Load a bundled JSON resource file."""
+    data: dict = json.loads(read_text(*relpath))
+    return data
+
+
+def render_devcontainer_spec() -> dict:
+    """Build the dev container spec from its base and the VS Code config.
+
+    The spec's ``settings`` are the shared VS Code settings plus the
+    container-only ones defined in the base, and its ``extensions`` are the
+    shared recommendations, so a project gets the same setup whether or not
+    it's opened in a container.
+    """
+    spec = load_json("devcontainer", "base.json")
+    settings = load_json("vscode", "settings.json")
+    # Container-only settings win, since they exist to override how things
+    # work inside the container
+    settings |= (
+        spec.get("customizations", {}).get("vscode", {}).get("settings", {})
+    )
+    extensions = load_json("vscode", "extensions.json")["recommendations"]
+    spec.setdefault("customizations", {})["vscode"] = {
+        "extensions": extensions,
+        "settings": settings,
+    }
+    return spec

--- a/calkit/resources/__init__.py
+++ b/calkit/resources/__init__.py
@@ -14,9 +14,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 
 DEVCONTAINER_FNAME = "devcontainer.json"
 VSCODE_FNAMES = ["settings.json", "extensions.json"]
+GITHUB_ACTIONS_FNAME = "example.yml"
+# The ref the example workflow ships with, which gets pinned to a released
+# version of Calkit when there is one to pin to
+ACTION_REF = "calkit/calkit/actions/run@main"
 
 
 def get_dir() -> str:
@@ -57,3 +62,23 @@ def render_devcontainer_spec() -> dict:
         "settings": settings,
     }
     return spec
+
+
+def render_github_actions_workflow(version: str | None = None) -> str:
+    """Return the example workflow, pinning the action to a Calkit version.
+
+    The action lives in this repo at ``actions/run``, so its refs are
+    Calkit's own release tags, and a project ends up pinned to the version
+    of Calkit that wrote its workflow. Rerunning ``calkit update github-actions`` after
+    upgrading moves the pin.
+    """
+    txt = read_text("github-actions", GITHUB_ACTIONS_FNAME)
+    if version is None:
+        import calkit
+
+        version = calkit.__version__
+    # Development installs report versions like 0.42.2.dev0+g21c9bb93, which
+    # isn't a tag anyone can reference, so those stay on main
+    if re.fullmatch(r"\d+\.\d+\.\d+", version):
+        txt = txt.replace(ACTION_REF, f"calkit/calkit/actions/run@v{version}")
+    return txt

--- a/calkit/resources/devcontainer/Dockerfile
+++ b/calkit/resources/devcontainer/Dockerfile
@@ -1,5 +1,9 @@
 FROM mcr.microsoft.com/devcontainers/python:dev-3.13-bullseye
 
+# GHCR links a package to the repo named here, which is what makes the
+# package inherit this repo's permissions and show its source
+LABEL org.opencontainers.image.source=https://github.com/calkit/calkit
+
 # Install Miniforge
 ARG MINIFORGE_NAME=Miniforge3
 ARG MINIFORGE_VERSION=26.3.2-0

--- a/calkit/resources/devcontainer/Dockerfile
+++ b/calkit/resources/devcontainer/Dockerfile
@@ -23,7 +23,7 @@ ENV PATH=${CONDA_DIR}/bin:${PATH}
 RUN rm -f /etc/apt/sources.list.d/yarn.list && \
     apt-get update > /dev/null && \
     apt-get install --no-install-recommends --yes \
-        wget bzip2 ca-certificates \
+        wget curl bzip2 ca-certificates \
         git \
         tini \
         > /dev/null && \

--- a/calkit/resources/devcontainer/Dockerfile
+++ b/calkit/resources/devcontainer/Dockerfile
@@ -1,0 +1,68 @@
+FROM mcr.microsoft.com/devcontainers/python:dev-3.13-bullseye
+
+# Install Miniforge
+ARG MINIFORGE_NAME=Miniforge3
+ARG MINIFORGE_VERSION=26.3.2-0
+ARG TARGETPLATFORM
+
+ENV CONDA_DIR=/opt/conda
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PATH=${CONDA_DIR}/bin:${PATH}
+
+# 1. Install just enough for conda to work
+# 2. Keep $HOME clean (no .wget-hsts file), since HSTS isn't useful in this context
+# 3. Install miniforge from GitHub releases
+# 4. Apply some cleanup tips from https://jcrist.github.io/conda-docker-tips.html
+#    Particularly, we remove pyc and a files. The default install has no js, we can skip that
+# 5. Activate base by default when running as any *non-root* user as well
+#    Good security practice requires running most workloads as non-root
+#    This makes sure any non-root users created also have base activated
+#    for their interactive shells.
+# 6. Activate base by default when running as root as well
+#    The root user is already created, so won't pick up changes to /etc/skel
+RUN rm -f /etc/apt/sources.list.d/yarn.list && \
+    apt-get update > /dev/null && \
+    apt-get install --no-install-recommends --yes \
+        wget bzip2 ca-certificates \
+        git \
+        tini \
+        > /dev/null && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget --no-hsts --quiet https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/${MINIFORGE_NAME}-${MINIFORGE_VERSION}-Linux-$(uname -m).sh -O /tmp/miniforge.sh && \
+    /bin/bash /tmp/miniforge.sh -b -p ${CONDA_DIR} && \
+    rm /tmp/miniforge.sh && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> /etc/skel/.bashrc && \
+    echo ". ${CONDA_DIR}/etc/profile.d/conda.sh && conda activate base" >> ~/.bashrc
+
+# Downgrade libsqlite
+# See https://github.com/iterative/dvc/issues/10692#issuecomment-2674679552
+RUN conda install -y libsqlite=3.48.0 && \
+    conda clean --tarballs --index-cache --packages --yes && \
+    find ${CONDA_DIR} -follow -type f -name '*.a' -delete && \
+    find ${CONDA_DIR} -follow -type f -name '*.pyc' -delete && \
+    conda clean --force-pkgs-dirs --all --yes
+
+# Install uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /uvx /bin/
+
+# Install Pixi
+ARG PIXI_VERSION=v0.69.0
+RUN curl -L -o /usr/local/bin/pixi -fsSL --compressed "https://github.com/prefix-dev/pixi/releases/download/${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \
+    && chmod +x /usr/local/bin/pixi \
+    && pixi info
+
+# Add init scripts
+ENV INIT_SCRIPTS_DIR=/usr/local/share/devcontainer-init
+RUN mkdir -p ${INIT_SCRIPTS_DIR}
+COPY scripts/post-create.sh ${INIT_SCRIPTS_DIR}
+COPY scripts/post-start.sh ${INIT_SCRIPTS_DIR}
+COPY scripts/update-content.sh ${INIT_SCRIPTS_DIR}
+COPY scripts/check-envs.sh ${INIT_SCRIPTS_DIR}
+
+# Install Calkit
+# Released images pin the version they were built for; local builds get
+# whatever is latest on PyPI
+ARG CALKIT_VERSION=
+RUN uv pip install --system --no-cache-dir \
+    "calkit-python${CALKIT_VERSION:+==${CALKIT_VERSION}}"

--- a/calkit/resources/devcontainer/README.md
+++ b/calkit/resources/devcontainer/README.md
@@ -30,11 +30,16 @@ make devcontainer-image
 This builds the image for the local platform and smoke tests it.
 CI builds it on every pull request that touches this directory, and pushes
 a multi-platform build to `ghcr.io/calkit/devcontainer` on release, pinned
-to the Calkit version being released via the `CALKIT_VERSION` build arg.
+to the Calkit version being released via the `CALKIT_VERSION` build arg,
+tagged `latest` and `<version>`.
+Image tags carry no `v` prefix, matching how the images this one builds on
+are tagged, so they differ from the Git tag they're built from.
 
-Note that pushing to the `calkit/devcontainer` package requires that
-package's Actions access settings on GitHub to grant write access to the
-`calkit/calkit` repo.
+The package predates this repo, so pushing to it requires that the package's
+[settings](https://github.com/orgs/calkit/packages/container/devcontainer/settings)
+grant `calkit/calkit` the write role under "Manage Actions access".
+The `org.opencontainers.image.source` label in the `Dockerfile` is what
+links the package to this repo once that push happens.
 
 ## Testing the container itself
 

--- a/calkit/resources/devcontainer/README.md
+++ b/calkit/resources/devcontainer/README.md
@@ -1,0 +1,44 @@
+# Calkit dev container
+
+A dev container spec for working on Calkit projects,
+and the image it runs, `ghcr.io/calkit/devcontainer`.
+To add the spec to a project, or update it to the latest version, run:
+
+```sh
+calkit update devcontainer
+```
+
+## Files
+
+- `base.json`: The spec, minus the VS Code extensions and settings shared
+  with [`../vscode`](../vscode).
+  Edit this to change the image, features, lifecycle hooks, or any setting
+  that should only apply inside the container.
+- `devcontainer.json`: Generated from `base.json` and `../vscode`.
+  Don't edit it by hand; run `make sync-resources` instead.
+  This is the file copied into projects.
+- `Dockerfile`: The image, which bundles conda, uv, Pixi, and Calkit itself.
+- `scripts/`: Lifecycle hook scripts, baked into the image at
+  `$INIT_SCRIPTS_DIR`.
+
+## Building the image
+
+```sh
+make devcontainer-image
+```
+
+This builds the image for the local platform and smoke tests it.
+CI builds it on every pull request that touches this directory, and pushes
+a multi-platform build to `ghcr.io/calkit/devcontainer` on release, pinned
+to the Calkit version being released via the `CALKIT_VERSION` build arg.
+
+Note that pushing to the `calkit/devcontainer` package requires that
+package's Actions access settings on GitHub to grant write access to the
+`calkit/calkit` repo.
+
+## Testing the container itself
+
+To open a project in a locally built image rather than the published one,
+build the image as above, then point the project's
+`.devcontainer/devcontainer.json` at the `calkit/devcontainer:dev` tag it
+produces and run "Dev Containers: Rebuild and Reopen in Container".

--- a/calkit/resources/devcontainer/base.json
+++ b/calkit/resources/devcontainer/base.json
@@ -1,0 +1,25 @@
+{
+  "image": "ghcr.io/calkit/devcontainer:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/julialang/devcontainer-features/julia:1": {
+      "channel": "release"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.terminal.activateEnvironment": false,
+        "python.terminal.activateEnvInCurrentTerminal": false,
+        "redhat.telemetry.enabled": true,
+        "window.menuBarVisibility": "classic",
+        "workbench.colorTheme": "Atom One Dark",
+        "editor.minimap.enabled": false
+      }
+    }
+  },
+  "initializeCommand": "mkdir -p .calkit/temp && echo '*' > .calkit/temp/.gitignore",
+  "postCreateCommand": "bash $INIT_SCRIPTS_DIR/post-create.sh",
+  "updateContentCommand": "bash $INIT_SCRIPTS_DIR/update-content.sh",
+  "postStartCommand": "bash $INIT_SCRIPTS_DIR/post-start.sh"
+}

--- a/calkit/resources/devcontainer/devcontainer.json
+++ b/calkit/resources/devcontainer/devcontainer.json
@@ -1,0 +1,58 @@
+{
+  "image": "ghcr.io/calkit/devcontainer:latest",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/julialang/devcontainer-features/julia:1": {
+      "channel": "release"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "Calkit.calkit-vscode",
+        "james-yu.latex-workshop",
+        "lakefs.lakefs-dvc",
+        "esbenp.prettier-vscode",
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.autopep8",
+        "ms-toolsai.jupyter",
+        "ms-toolsai.jupyter-keymap",
+        "ms-toolsai.jupyter-renderers",
+        "ms-toolsai.vscode-jupyter-cell-tags",
+        "ms-toolsai.vscode-jupyter-slideshow",
+        "streetsidesoftware.code-spell-checker",
+        "redhat.vscode-yaml",
+        "akamud.vscode-theme-onedark",
+        "mechatroner.rainbow-csv",
+        "julialang.language-julia"
+      ],
+      "settings": {
+        "latex-workshop.bibtex-format.tab": "4 spaces",
+        "latex-workshop.latex.autoBuild.run": "onSave",
+        "latex-workshop.docker.image.latex": "texlive/texlive:latest-full",
+        "latex-workshop.docker.enabled": true,
+        "dvc.doNotShowSetupAfterInstall": true,
+        "workbench.editorAssociations": {
+          "*.pdf": "latex-workshop-pdf-hook"
+        },
+        "git.autofetch": true,
+        "cSpell.userWords": [
+          "calkit",
+          "Calkit"
+        ],
+        "python.terminal.activateEnvironment": false,
+        "python.terminal.activateEnvInCurrentTerminal": false,
+        "redhat.telemetry.enabled": true,
+        "window.menuBarVisibility": "classic",
+        "workbench.colorTheme": "Atom One Dark",
+        "editor.minimap.enabled": false
+      }
+    }
+  },
+  "initializeCommand": "mkdir -p .calkit/temp && echo '*' > .calkit/temp/.gitignore",
+  "postCreateCommand": "bash $INIT_SCRIPTS_DIR/post-create.sh",
+  "updateContentCommand": "bash $INIT_SCRIPTS_DIR/update-content.sh",
+  "postStartCommand": "bash $INIT_SCRIPTS_DIR/post-start.sh"
+}

--- a/calkit/resources/devcontainer/scripts/check-envs.sh
+++ b/calkit/resources/devcontainer/scripts/check-envs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Run `calkit check envs` fully detached from the lifecycle hook that invoked
+# it, so the dev container/Codespace gets marked ready immediately. Setting up
+# environments can involve multi-GB image pulls (texlive, for example), which
+# would otherwise leave the user staring at a spinner for many minutes.
+#
+# Progress is logged to $HOME/.cache/check-envs.log.
+
+CACHE_DIR="$HOME/.cache"
+mkdir -p "$CACHE_DIR"
+LOGFILE="$CACHE_DIR/check-envs.log"
+
+# How long to wait for the Docker daemon to become accessible, in seconds
+MAX_WAIT=300
+
+if [ "${1:-}" != "--worker" ]; then
+    : > "$LOGFILE"
+    # Prefer setsid to fully detach; fall back to nohup if it's unavailable
+    if command -v setsid > /dev/null 2>&1; then
+        setsid bash "$0" --worker > /dev/null 2>&1 < /dev/null &
+    else
+        nohup bash "$0" --worker > /dev/null 2>&1 < /dev/null &
+    fi
+    echo "Started environment check in the background (PID: $!)"
+    echo "Progress is being logged to $LOGFILE"
+    exit 0
+fi
+
+# Everything below here runs in the detached background process
+
+log() {
+    printf '[%s] %s\n' "$(date +%Y-%m-%dT%H:%M:%S%z)" "$*" >> "$LOGFILE"
+}
+
+log "Waiting up to ${MAX_WAIT}s for the Docker daemon"
+COUNT=0
+until docker info > /dev/null 2>&1; do
+    COUNT=$((COUNT + 1))
+    if [ "$COUNT" -ge "$MAX_WAIT" ]; then
+        log "ERROR: Docker daemon not accessible after ${MAX_WAIT}s; skipping environment check"
+        exit 1
+    fi
+    sleep 1
+done
+log "Docker daemon is up after ${COUNT}s"
+
+# shellcheck disable=SC1091
+. /opt/conda/bin/activate 2> /dev/null || true
+
+log "Running: calkit check envs"
+calkit check envs >> "$LOGFILE" 2>&1
+EXIT_CODE=$?
+if [ "$EXIT_CODE" -eq 0 ]; then
+    log "Environment check completed successfully"
+else
+    log "Environment check failed with exit code ${EXIT_CODE}"
+fi

--- a/calkit/resources/devcontainer/scripts/post-create.sh
+++ b/calkit/resources/devcontainer/scripts/post-create.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+TEMP_ENV=.calkit/temp/.env
+
+set -euo pipefail
+
+mkdir -p "$(dirname "$TEMP_ENV")"
+
+# Read a single KEY=value pair out of the staged env file. The file lives in
+# the workspace, so it's treated as untrusted input and parsed rather than
+# sourced, which would execute whatever happens to be in it.
+read_staged_var() {
+	local key="$1" line
+	[ -f "$TEMP_ENV" ] || return 0
+	line=$(grep -m 1 "^${key}=" "$TEMP_ENV" 2>/dev/null) || return 0
+	line="${line#"${key}="}"
+	line="${line%$'\r'}"
+	# Strip one layer of surrounding quotes, if present
+	case "$line" in
+		\"*\") line="${line#\"}" && line="${line%\"}" ;;
+		\'*\') line="${line#\'}" && line="${line%\'}" ;;
+	esac
+	printf '%s' "$line"
+}
+
+# Prefer values staged by initializeCommand or a previous container run, then
+# anything already in the environment, then the container's own calkit config
+STAGED_TOKEN=$(read_staged_var CALKIT_TOKEN)
+STAGED_DVC_TOKEN=$(read_staged_var CALKIT_DVC_TOKEN)
+
+CALKIT_TOKEN=${STAGED_TOKEN:-${CALKIT_TOKEN:-}}
+CALKIT_DVC_TOKEN=${STAGED_DVC_TOKEN:-${CALKIT_DVC_TOKEN:-}}
+
+if [ -z "${CALKIT_TOKEN:-}" ]; then
+	CALKIT_TOKEN=$(calkit config get token 2>/dev/null || true)
+fi
+
+if [ -z "${CALKIT_DVC_TOKEN:-}" ]; then
+	CALKIT_DVC_TOKEN=$(calkit config get dvc_token 2>/dev/null || true)
+fi
+
+if [ -n "${CALKIT_TOKEN:-}" ]; then
+	calkit config set token "$CALKIT_TOKEN"
+fi
+
+if [ -n "${CALKIT_DVC_TOKEN:-}" ]; then
+	calkit config set dvc_token "$CALKIT_DVC_TOKEN"
+fi
+
+rm -f "$TEMP_ENV"

--- a/calkit/resources/devcontainer/scripts/post-start.sh
+++ b/calkit/resources/devcontainer/scripts/post-start.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+. /opt/conda/bin/activate
+
+CACHE_DIR="$HOME/.cache"
+mkdir -p "$CACHE_DIR"
+
+LOGFILE="$CACHE_DIR/calkit-codespace.log"
+
+log() {
+	printf '%s\n' "$*" >> "$LOGFILE"
+}
+
+# Calkit setup is optional here, so every step below bails out cleanly rather
+# than failing the hook and making the container look like it started badly
+if ! git rev-parse --git-dir > /dev/null 2>&1; then
+	log "Workspace is not a Git repository; skipping calkit config and pull"
+	exit 0
+fi
+
+if ! git remote get-url origin > /dev/null 2>&1; then
+	if [ -z "${GITHUB_REPOSITORY:-}" ]; then
+		log "No origin remote and GITHUB_REPOSITORY is unset; skipping calkit config and pull"
+		exit 0
+	fi
+	if git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git" 2>> "$LOGFILE"; then
+		log "Added origin remote from GITHUB_REPOSITORY=${GITHUB_REPOSITORY}"
+	else
+		log "Failed to add origin remote; skipping calkit config and pull"
+		exit 0
+	fi
+fi
+
+if calkit config github-codespace >> "$LOGFILE" 2>&1; then
+	log "Configured Calkit for GitHub Codespaces"
+else
+	log "calkit config github-codespace failed; see log output above"
+fi
+
+if calkit pull >> "$LOGFILE" 2>&1; then
+	log "Pulled Calkit/DVC content"
+else
+	log "calkit pull failed; see log output above"
+fi

--- a/calkit/resources/devcontainer/scripts/update-content.sh
+++ b/calkit/resources/devcontainer/scripts/update-content.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+conda init bash
+# shellcheck disable=SC1091
+. /opt/conda/bin/activate
+
+# Kick off the environment check in the background so it doesn't hold up the
+# container being marked ready; check-envs.sh detaches and waits for the Docker
+# daemon itself
+bash "${INIT_SCRIPTS_DIR:-/usr/local/share/devcontainer-init}/check-envs.sh"

--- a/calkit/resources/github-actions/example.yml
+++ b/calkit/resources/github-actions/example.yml
@@ -1,0 +1,36 @@
+name: Run pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  id-token: write
+
+# Make sure we only ever run one per branch so we don't have issues pushing
+# after running the pipeline
+concurrency:
+  group: calkit-run-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  main:
+    name: Run
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # For PRs, checkout the head ref to avoid detached HEAD
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure Git credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      # This action automatically runs necessary setup steps based on environments
+      - name: Run Calkit
+        uses: calkit/calkit/actions/run@main

--- a/calkit/resources/vscode/README.md
+++ b/calkit/resources/vscode/README.md
@@ -1,0 +1,23 @@
+# VS Code config
+
+Recommended VS Code settings and extensions for Calkit projects.
+To add these to a project, or update them to the latest version, run:
+
+```sh
+calkit update vscode-config
+```
+
+This writes `.vscode/settings.json` and `.vscode/extensions.json`,
+and commits them.
+
+These files are also the source for the dev container's
+`customizations.vscode` section, so a project gets the same editor setup
+whether it's opened locally or in a container.
+After editing them, run `make sync-resources` to regenerate
+[`../devcontainer/devcontainer.json`](../devcontainer/devcontainer.json).
+
+Settings that only make sense inside the container,
+like the color theme and Python terminal activation,
+live in [`../devcontainer/base.json`](../devcontainer/base.json) instead,
+since these settings go into a user's project and shouldn't override
+their own preferences.

--- a/calkit/resources/vscode/extensions.json
+++ b/calkit/resources/vscode/extensions.json
@@ -1,0 +1,22 @@
+{
+  "recommendations": [
+    "Calkit.calkit-vscode",
+    "james-yu.latex-workshop",
+    "lakefs.lakefs-dvc",
+    "esbenp.prettier-vscode",
+    "ms-python.python",
+    "ms-python.vscode-pylance",
+    "ms-python.debugpy",
+    "ms-python.autopep8",
+    "ms-toolsai.jupyter",
+    "ms-toolsai.jupyter-keymap",
+    "ms-toolsai.jupyter-renderers",
+    "ms-toolsai.vscode-jupyter-cell-tags",
+    "ms-toolsai.vscode-jupyter-slideshow",
+    "streetsidesoftware.code-spell-checker",
+    "redhat.vscode-yaml",
+    "akamud.vscode-theme-onedark",
+    "mechatroner.rainbow-csv",
+    "julialang.language-julia"
+  ]
+}

--- a/calkit/resources/vscode/settings.json
+++ b/calkit/resources/vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "latex-workshop.bibtex-format.tab": "4 spaces",
+  "latex-workshop.latex.autoBuild.run": "onSave",
+  "latex-workshop.docker.image.latex": "texlive/texlive:latest-full",
+  "latex-workshop.docker.enabled": true,
+  "dvc.doNotShowSetupAfterInstall": true,
+  "workbench.editorAssociations": {
+    "*.pdf": "latex-workshop-pdf-hook"
+  },
+  "git.autofetch": true,
+  "cSpell.userWords": [
+    "calkit",
+    "Calkit"
+  ]
+}

--- a/calkit/tests/cli/test_update.py
+++ b/calkit/tests/cli/test_update.py
@@ -1,5 +1,7 @@
 """Tests for ``cli.update``."""
 
+import json
+import os
 import subprocess
 import sys
 
@@ -7,9 +9,40 @@ import pytest
 from typer.testing import CliRunner
 
 import calkit
+import calkit.resources
 from calkit.cli.update import update_app
 
 runner = CliRunner()
+
+
+def test_update_devcontainer_and_vscode_config(tmp_dir, monkeypatch):
+    # Both write bundled resources, so neither should touch the network
+    def fail(*args, **kwargs):
+        raise AssertionError("Should not make any HTTP requests")
+
+    import requests
+
+    monkeypatch.setattr(requests, "get", fail)
+    subprocess.check_call(["calkit", "init"])
+    result = runner.invoke(update_app, ["devcontainer"])
+    assert result.exit_code == 0
+    with open(os.path.join(".devcontainer", "devcontainer.json")) as f:
+        assert json.load(f) == calkit.resources.load_json(
+            "devcontainer", calkit.resources.DEVCONTAINER_FNAME
+        )
+    result = runner.invoke(update_app, ["vscode-config"])
+    assert result.exit_code == 0
+    for fname in calkit.resources.VSCODE_FNAMES:
+        with open(os.path.join(".vscode", fname)) as f:
+            assert json.load(f) == calkit.resources.load_json("vscode", fname)
+    repo = calkit.git.get_repo()
+    assert repo.git.ls_files(".devcontainer")
+    assert repo.git.ls_files(".vscode")
+    assert not repo.git.status("--porcelain")
+    # Both commands should be safe to rerun
+    assert runner.invoke(update_app, ["devcontainer"]).exit_code == 0
+    assert runner.invoke(update_app, ["vscode-config"]).exit_code == 0
+    assert not repo.git.status("--porcelain")
 
 
 def test_update_uv_env(tmp_dir):

--- a/calkit/tests/cli/test_update.py
+++ b/calkit/tests/cli/test_update.py
@@ -51,6 +51,65 @@ def test_update_project_config(tmp_dir, monkeypatch):
     assert not repo.git.status("--porcelain")
 
 
+def test_update_github_actions(tmp_dir):
+    subprocess.check_call(["calkit", "init"])
+    workflow_dir = os.path.join(".github", "workflows")
+    ref = calkit.resources.get_action_ref()
+    # A project that mentions Calkit in an unrelated workflow should get its
+    # own, and that workflow should be left alone
+    os.makedirs(workflow_dir, exist_ok=True)
+    other_fpath = os.path.join(workflow_dir, "docs.yml")
+    other_txt = "name: Docs\njobs:\n  main:\n    steps:\n      - run: calkit\n"
+    with open(other_fpath, "w") as f:
+        f.write(other_txt)
+    assert runner.invoke(update_app, ["github-actions"]).exit_code == 0
+    with open(other_fpath) as f:
+        assert f.read() == other_txt
+    out_fpath = os.path.join(workflow_dir, "run-calkit.yml")
+    with open(out_fpath) as f:
+        assert f.read() == calkit.resources.render_github_actions_workflow()
+    # A workflow written by an older version of Calkit, which is still the
+    # example, should be replaced outright so it picks up any other changes
+    # to it, wherever it lives
+    os.remove(out_fpath)
+    old_fpath = os.path.join(workflow_dir, "run.yml")
+    with open(old_fpath, "w") as f:
+        f.write(
+            calkit.resources.render_github_actions_workflow(version="0.1.0")
+        )
+    assert runner.invoke(update_app, ["github-actions"]).exit_code == 0
+    assert not os.path.isfile(out_fpath)
+    with open(old_fpath) as f:
+        assert f.read() == calkit.resources.render_github_actions_workflow()
+    # A customized workflow, here one still pointing at the action's previous
+    # home, should only have its action ref updated
+    custom_txt = (
+        "name: Run pipeline\n"
+        "jobs:\n"
+        "  main:\n"
+        "    steps:\n"
+        "      - uses: actions/checkout@v4\n"
+        "      - uses: calkit/run-action@v2\n"
+        "        with:\n"
+        "          extra-args: --no-check\n"
+        "      - run: echo custom\n"
+    )
+    with open(old_fpath, "w") as f:
+        f.write(custom_txt)
+    assert runner.invoke(update_app, ["github-actions"]).exit_code == 0
+    with open(old_fpath) as f:
+        updated_txt = f.read()
+    assert updated_txt == custom_txt.replace("calkit/run-action@v2", ref)
+    # Rerunning should be a no-op, and shouldn't leave anything uncommitted
+    repo = calkit.git.get_repo()
+    repo.git.add(".github")
+    repo.git.commit(["-m", "Add workflows"])
+    assert runner.invoke(update_app, ["github-actions"]).exit_code == 0
+    with open(old_fpath) as f:
+        assert f.read() == updated_txt
+    assert not repo.git.status("--porcelain")
+
+
 def test_update_uv_env(tmp_dir):
     subprocess.check_call(["calkit", "init"])
     subprocess.check_call(

--- a/calkit/tests/cli/test_update.py
+++ b/calkit/tests/cli/test_update.py
@@ -15,8 +15,8 @@ from calkit.cli.update import update_app
 runner = CliRunner()
 
 
-def test_update_devcontainer_and_vscode_config(tmp_dir, monkeypatch):
-    # Both write bundled resources, so neither should touch the network
+def test_update_project_config(tmp_dir, monkeypatch):
+    # These all write bundled resources, so none should touch the network
     def fail(*args, **kwargs):
         raise AssertionError("Should not make any HTTP requests")
 
@@ -35,13 +35,19 @@ def test_update_devcontainer_and_vscode_config(tmp_dir, monkeypatch):
     for fname in calkit.resources.VSCODE_FNAMES:
         with open(os.path.join(".vscode", fname)) as f:
             assert json.load(f) == calkit.resources.load_json("vscode", fname)
+    result = runner.invoke(update_app, ["github-actions"])
+    assert result.exit_code == 0
+    with open(os.path.join(".github", "workflows", "run-calkit.yml")) as f:
+        assert f.read() == calkit.resources.render_github_actions_workflow()
     repo = calkit.git.get_repo()
     assert repo.git.ls_files(".devcontainer")
     assert repo.git.ls_files(".vscode")
+    assert repo.git.ls_files(".github")
     assert not repo.git.status("--porcelain")
-    # Both commands should be safe to rerun
+    # All three should be safe to rerun
     assert runner.invoke(update_app, ["devcontainer"]).exit_code == 0
     assert runner.invoke(update_app, ["vscode-config"]).exit_code == 0
+    assert runner.invoke(update_app, ["github-actions"]).exit_code == 0
     assert not repo.git.status("--porcelain")
 
 

--- a/calkit/tests/test_resources.py
+++ b/calkit/tests/test_resources.py
@@ -9,7 +9,7 @@ import calkit
 import calkit.resources
 
 
-def test_resources():
+def test_resources(monkeypatch):
     resources_dir = calkit.resources.get_dir()
     assert os.path.isdir(resources_dir)
     spec = calkit.resources.load_json(
@@ -37,6 +37,25 @@ def test_resources():
     # base.json, which only applies inside the container
     for key in settings:
         assert not key.startswith(("workbench.colorTheme", "window."))
+    # Only the generated keys come from the VS Code config, so anything else
+    # the base customizes survives being merged with it
+    real_load_json = calkit.resources.load_json
+
+    def load_json_with_extra_customization(*relpath):
+        data = real_load_json(*relpath)
+        if relpath[-1] == "base.json":
+            data["customizations"]["vscode"]["snippets"] = ["python"]
+        return data
+
+    monkeypatch.setattr(
+        calkit.resources, "load_json", load_json_with_extra_customization
+    )
+    merged = calkit.resources.render_devcontainer_spec()["customizations"][
+        "vscode"
+    ]
+    assert merged["snippets"] == ["python"]
+    assert merged["extensions"] == extensions
+    assert merged["settings"] == customizations["settings"]
 
 
 def test_github_actions_workflow():
@@ -62,6 +81,36 @@ def test_github_actions_workflow():
         version="1.2.3.dev0+g21c9bb93"
     )
     assert calkit.resources.ACTION_REF in unpinned
+    # A project's workflow can be repinned in place, at whatever ref and in
+    # whatever style it was written, including the action's previous home,
+    # without touching anything else in it
+    for uses in [
+        "      - uses: calkit/run-action@v2\n",
+        '      - uses: "calkit/calkit/actions/run@v0.1.0"\n',
+        "        uses: calkit/calkit/actions/run@main\n",
+    ]:
+        custom = "# Custom\njobs:\n  main:\n    steps:\n" + uses
+        assert calkit.resources.uses_run_action(custom)
+        updated = calkit.resources.set_action_ref(custom, version="1.2.3")
+        assert "calkit/calkit/actions/run@v1.2.3" in updated
+        assert "run-action" not in updated
+        assert updated.startswith("# Custom\n")
+        assert len(updated.splitlines()) == len(custom.splitlines())
+    # Steps that use other actions, or mention the action outside a ref,
+    # must be left alone
+    other = "      - uses: actions/checkout@v4\n# calkit/run-action@v2\n"
+    assert not calkit.resources.uses_run_action(other)
+    assert calkit.resources.set_action_ref(other, version="1.2.3") == other
+    # Whether a project's workflow is still the example is what decides if
+    # it gets replaced wholesale or only repinned, so the pin itself, and
+    # line endings Git may have translated, can't affect that
+    assert calkit.resources.is_default_github_actions_workflow(pinned)
+    assert calkit.resources.is_default_github_actions_workflow(
+        unpinned.replace("\n", "\r\n")
+    )
+    assert not calkit.resources.is_default_github_actions_workflow(
+        pinned + "\n      - run: echo custom\n"
+    )
     # The bundled copy is generated from the action's own example, which is
     # only present in the repo, not in an installed package
     repo_copy = os.path.join(

--- a/calkit/tests/test_resources.py
+++ b/calkit/tests/test_resources.py
@@ -3,6 +3,9 @@
 import os
 import re
 
+import pytest
+
+import calkit
 import calkit.resources
 
 
@@ -34,6 +37,54 @@ def test_resources():
     # base.json, which only applies inside the container
     for key in settings:
         assert not key.startswith(("workbench.colorTheme", "window."))
+
+
+def test_github_actions_workflow():
+    workflow = calkit.ryaml.load(
+        calkit.resources.read_text(
+            "github-actions", calkit.resources.GITHUB_ACTIONS_FNAME
+        )
+    )
+    steps = workflow["jobs"]["main"]["steps"]
+    assert any(
+        step.get("uses") == calkit.resources.ACTION_REF for step in steps
+    )
+    # The action needs these to push results and to exchange an OIDC token
+    # for a Calkit one
+    assert workflow["permissions"]["contents"] == "write"
+    assert workflow["permissions"]["id-token"] == "write"
+    # Released versions get pinned to a tag that exists in this repo; dev
+    # versions have no tag to point at, so they stay on main
+    pinned = calkit.resources.render_github_actions_workflow(version="1.2.3")
+    assert "uses: calkit/calkit/actions/run@v1.2.3" in pinned
+    assert calkit.resources.ACTION_REF not in pinned
+    unpinned = calkit.resources.render_github_actions_workflow(
+        version="1.2.3.dev0+g21c9bb93"
+    )
+    assert calkit.resources.ACTION_REF in unpinned
+    # The bundled copy is generated from the action's own example, which is
+    # only present in the repo, not in an installed package
+    repo_copy = os.path.join(
+        os.path.dirname(os.path.dirname(calkit.resources.get_dir())),
+        "actions",
+        "run",
+        calkit.resources.GITHUB_ACTIONS_FNAME,
+    )
+    if not os.path.isfile(repo_copy):
+        pytest.skip("Not running from a repo checkout")
+    with open(repo_copy) as f:
+        assert f.read() == calkit.resources.read_text(
+            "github-actions", calkit.resources.GITHUB_ACTIONS_FNAME
+        )
+    # Everything the workflow does with the action is defined by it
+    action_path = os.path.join(os.path.dirname(repo_copy), "action.yml")
+    with open(action_path) as f:
+        action = calkit.ryaml.load(f)
+    step = next(
+        s for s in steps if s.get("uses") == calkit.resources.ACTION_REF
+    )
+    for name in step.get("with", {}):
+        assert name in action["inputs"]
 
 
 def test_devcontainer_image_sources():

--- a/calkit/tests/test_resources.py
+++ b/calkit/tests/test_resources.py
@@ -1,0 +1,59 @@
+"""Tests for ``resources``."""
+
+import os
+import re
+
+import calkit.resources
+
+
+def test_resources():
+    resources_dir = calkit.resources.get_dir()
+    assert os.path.isdir(resources_dir)
+    spec = calkit.resources.load_json(
+        "devcontainer", calkit.resources.DEVCONTAINER_FNAME
+    )
+    # The committed spec must match what the VS Code config generates, else
+    # the two would drift; run `make sync-resources` if this fails
+    assert spec == calkit.resources.render_devcontainer_spec()
+    assert spec["image"].startswith("ghcr.io/calkit/devcontainer")
+    settings = calkit.resources.load_json("vscode", "settings.json")
+    extensions = calkit.resources.load_json("vscode", "extensions.json")[
+        "recommendations"
+    ]
+    customizations = spec["customizations"]["vscode"]
+    for key, value in settings.items():
+        assert customizations["settings"][key] == value
+    assert customizations["extensions"] == extensions
+    # Extension IDs are 'publisher.name', and a typo in one means it silently
+    # never gets installed
+    assert len(set(extensions)) == len(extensions)
+    for ext in extensions:
+        assert re.fullmatch(r"[\w-]+\.[\w-]+", ext), ext
+    # The VS Code settings land in a user's project, so they mustn't override
+    # personal preferences; those settings belong in the dev container's
+    # base.json, which only applies inside the container
+    for key in settings:
+        assert not key.startswith(("workbench.colorTheme", "window."))
+
+
+def test_devcontainer_image_sources():
+    resources_dir = calkit.resources.get_dir()
+    devcontainer_dir = os.path.join(resources_dir, "devcontainer")
+    with open(os.path.join(devcontainer_dir, "Dockerfile")) as f:
+        dockerfile = f.read()
+    scripts = os.listdir(os.path.join(devcontainer_dir, "scripts"))
+    assert scripts
+    for fname in scripts:
+        assert f"COPY scripts/{fname}" in dockerfile
+    # Every lifecycle hook the spec calls must be one of those scripts
+    spec = calkit.resources.load_json(
+        "devcontainer", calkit.resources.DEVCONTAINER_FNAME
+    )
+    hooks = [
+        v
+        for k, v in spec.items()
+        if k.endswith("Command") and "$INIT_SCRIPTS_DIR" in str(v)
+    ]
+    assert hooks
+    for hook in hooks:
+        assert hook.split("$INIT_SCRIPTS_DIR/")[-1].strip() in scripts

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2318,32 +2318,32 @@ Options:
 
 Update objects.
 
-| Command                                               | Description                                                                         |
-| ----------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [`devcontainer`](#subcommand-update-devcontainer)     | Update a project's devcontainer to match the latest Calkit spec.                    |
-| [`license`](#subcommand-update-license)               | Update license with a reasonable default (MIT for code, CC-BY-4.0 for other files). |
-| [`release`](#subcommand-update-release)               | Update a release.                                                                   |
-| [`vscode-config`](#subcommand-update-vscode-config)   | Update a project's VS Code config to match the latest Calkit recommendations.       |
-| [`github-actions`](#subcommand-update-github-actions) | Update a project's GitHub Actions to match the latest Calkit recommendations.       |
-| [`notebook`](#subcommand-update-notebook)             | Update notebook information.                                                        |
-| [`agent-skills`](#subcommand-update-agent-skills)     | Copy packaged Calkit agent skills to `~/.agents/skills`.                            |
-| [`uv-env`](#subcommand-update-uv-env)                 | Update a uv environment.                                                            |
-| [`pixi-env`](#subcommand-update-pixi-env)             | Update a pixi environment.                                                          |
-| [`julia-env`](#subcommand-update-julia-env)           | Update a Julia environment.                                                         |
-| [`conda-env`](#subcommand-update-conda-env)           | Update a conda environment spec file.                                               |
-| [`docker-env`](#subcommand-update-docker-env)         | Update a docker environment.                                                        |
-| [`slurm-env`](#subcommand-update-slurm-env)           | Update a SLURM environment.                                                         |
-| [`env`](#subcommand-update-env)                       | Update an environment.                                                              |
-| [`environment`](#subcommand-update-environment)       | Update an environment.                                                              |
-| [`stage`](#subcommand-update-stage)                   | Update a pipeline stage in calkit.yaml.                                             |
-| [`figure`](#subcommand-update-figure)                 | Update a figure entry in calkit.yaml.                                               |
-| [`dataset`](#subcommand-update-dataset)               | Update a dataset entry in calkit.yaml.                                              |
+| Command                                               | Description                                                                          |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| [`devcontainer`](#subcommand-update-devcontainer)     | Update a project's devcontainer to match this version of Calkit's spec.              |
+| [`license`](#subcommand-update-license)               | Update license with a reasonable default (MIT for code, CC-BY-4.0 for other files).  |
+| [`release`](#subcommand-update-release)               | Update a release.                                                                    |
+| [`vscode-config`](#subcommand-update-vscode-config)   | Update a project's VS Code config to match this version of Calkit's recommendations. |
+| [`github-actions`](#subcommand-update-github-actions) | Update a project's GitHub Actions to match the latest Calkit recommendations.        |
+| [`notebook`](#subcommand-update-notebook)             | Update notebook information.                                                         |
+| [`agent-skills`](#subcommand-update-agent-skills)     | Copy packaged Calkit agent skills to `~/.agents/skills`.                             |
+| [`uv-env`](#subcommand-update-uv-env)                 | Update a uv environment.                                                             |
+| [`pixi-env`](#subcommand-update-pixi-env)             | Update a pixi environment.                                                           |
+| [`julia-env`](#subcommand-update-julia-env)           | Update a Julia environment.                                                          |
+| [`conda-env`](#subcommand-update-conda-env)           | Update a conda environment spec file.                                                |
+| [`docker-env`](#subcommand-update-docker-env)         | Update a docker environment.                                                         |
+| [`slurm-env`](#subcommand-update-slurm-env)           | Update a SLURM environment.                                                          |
+| [`env`](#subcommand-update-env)                       | Update an environment.                                                               |
+| [`environment`](#subcommand-update-environment)       | Update an environment.                                                               |
+| [`stage`](#subcommand-update-stage)                   | Update a pipeline stage in calkit.yaml.                                              |
+| [`figure`](#subcommand-update-figure)                 | Update a figure entry in calkit.yaml.                                                |
+| [`dataset`](#subcommand-update-dataset)               | Update a dataset entry in calkit.yaml.                                               |
 
 <a id="subcommand-update-devcontainer"></a>
 
 #### `calkit update devcontainer`
 
-Update a project's devcontainer to match the latest Calkit spec.
+Update a project's devcontainer to match this version of Calkit's spec.
 
 Usage:
 
@@ -2405,7 +2405,7 @@ Options:
 
 #### `calkit update vscode-config`
 
-Update a project's VS Code config to match the latest Calkit recommendations.
+Update a project's VS Code config to match this version of Calkit's recommendations.
 
 Usage:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2324,7 +2324,7 @@ Update objects.
 | [`license`](#subcommand-update-license)               | Update license with a reasonable default (MIT for code, CC-BY-4.0 for other files).  |
 | [`release`](#subcommand-update-release)               | Update a release.                                                                    |
 | [`vscode-config`](#subcommand-update-vscode-config)   | Update a project's VS Code config to match this version of Calkit's recommendations. |
-| [`github-actions`](#subcommand-update-github-actions) | Update a project's GitHub Actions to match the latest Calkit recommendations.        |
+| [`github-actions`](#subcommand-update-github-actions) | Update a project's GitHub Actions to match this version of Calkit's recommendations. |
 | [`notebook`](#subcommand-update-notebook)             | Update notebook information.                                                         |
 | [`agent-skills`](#subcommand-update-agent-skills)     | Copy packaged Calkit agent skills to `~/.agents/skills`.                             |
 | [`uv-env`](#subcommand-update-uv-env)                 | Update a uv environment.                                                             |
@@ -2424,7 +2424,7 @@ Options:
 
 #### `calkit update github-actions`
 
-Update a project's GitHub Actions to match the latest Calkit recommendations.
+Update a project's GitHub Actions to match this version of Calkit's recommendations.
 
 Usage:
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2426,6 +2426,8 @@ Options:
 
 Update a project's GitHub Actions to match this version of Calkit's recommendations.
 
+An existing workflow that runs the Calkit action is updated in place, pinning the action to this version of Calkit, so this is safe to rerun after upgrading.
+
 Usage:
 
 ```text

--- a/docs/latex.md
+++ b/docs/latex.md
@@ -116,8 +116,8 @@ It does mean the tracked diff keeps showing a merged branch's changes until
 the pipeline runs on the default branch again, which rebuilds it as the
 plain document.
 Running the pipeline in CI on pushes to the default branch keeps it current;
-the [run action](https://github.com/calkit/run-action) does that in its
-example workflow, and saves the result.
+the [run action](https://github.com/calkit/calkit/tree/main/actions/run) does that
+in its example workflow, and saves the result.
 
 <!-- prettier-ignore -->
 !!! note

--- a/docs/tutorials/github-actions.md
+++ b/docs/tutorials/github-actions.md
@@ -55,7 +55,7 @@ jobs:
       - name: Install Calkit
         run: uv tool install calkit-python
       - name: Run Calkit
-        uses: calkit/run-action@v2
+        uses: calkit/calkit/actions/run@main
 ```
 
 This particular example installs Calkit with uv,

--- a/docs/tutorials/github-actions.md
+++ b/docs/tutorials/github-actions.md
@@ -13,6 +13,10 @@ calkit update github-actions
 
 Note that this command can be run at any time to update to the latest
 recommended workflow configuration.
+The action is pinned to the version of Calkit that wrote the workflow,
+so after upgrading Calkit, rerun the command to move the pin.
+If the workflow has been customized, only the action's version is updated,
+and everything else in it is left alone.
 
 Inside `.github/workflows/run-calkit.yml` you'll then see something like:
 

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -4518,17 +4518,12 @@ async def post_project_overleaf_publication(
                 has_calkit_workflow = True
                 break
         if not has_calkit_workflow:
-            download_url = (
-                "https://raw.githubusercontent.com/calkit/"
-                "run-action/refs/heads/main/example.yml"
-            )
-            download_resp = requests.get(download_url)
             workflow_rel_path = os.path.join(
                 ".github", "workflows", "run-calkit.yml"
             )
             workflow_fpath = os.path.join(repo.working_dir, workflow_rel_path)
             with open(workflow_fpath, "w") as f:
-                f.write(download_resp.text)
+                f.write(calkit.resources.render_github_actions_workflow())
             repo.git.add(workflow_rel_path)
     commit_msg = (
         f"Import Overleaf project ID {overleaf_project_id} to '{path}'"

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -45,6 +45,7 @@ import app.projects
 import calkit
 import calkit.detect
 import calkit.latex
+import calkit.resources
 from app import (
     arxiv,
     github,
@@ -613,28 +614,18 @@ def post_project(
                 ryaml.dump(ck_info, f)
             repo.git.add("calkit.yaml")
             if project_in.template is None:
-                # Create devcontainer spec
-                dc_url = (
-                    "https://raw.githubusercontent.com/calkit/devcontainer/"
-                    "refs/heads/main/devcontainer.json"
-                )
-                # A dev container spec is a nice-to-have, and can be added
-                # later with the dev container endpoint, so don't fail project
-                # creation if GitHub is slow or the file has moved. Writing a
-                # non-200 body would put an error page in devcontainer.json.
-                try:
-                    dc_resp = requests.get(dc_url, timeout=15)
-                    dc_resp.raise_for_status()
-                except requests.RequestException as e:
-                    logger.warning(f"Failed to fetch dev container spec: {e}")
-                    dc_resp = None
-                if dc_resp is not None:
-                    dc_dir = os.path.join(repo.working_dir, ".devcontainer")
-                    os.makedirs(dc_dir, exist_ok=True)
-                    dc_fpath = os.path.join(dc_dir, "devcontainer.json")
-                    with open(dc_fpath, "w") as f:
-                        f.write(dc_resp.text)
-                    repo.git.add(".devcontainer")
+                # Create devcontainer spec from the one bundled with Calkit
+                dc_dir = os.path.join(repo.working_dir, ".devcontainer")
+                os.makedirs(dc_dir, exist_ok=True)
+                dc_fpath = os.path.join(dc_dir, "devcontainer.json")
+                with open(dc_fpath, "w") as f:
+                    f.write(
+                        calkit.resources.read_text(
+                            "devcontainer",
+                            calkit.resources.DEVCONTAINER_FNAME,
+                        )
+                    )
+                repo.git.add(".devcontainer")
             # Create the README
             logger.info("Creating README.md")
             with open(os.path.join(repo.working_dir, "README.md"), "w") as f:

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -618,7 +618,7 @@ def post_project(
                 dc_dir = os.path.join(repo.working_dir, ".devcontainer")
                 os.makedirs(dc_dir, exist_ok=True)
                 dc_fpath = os.path.join(dc_dir, "devcontainer.json")
-                with open(dc_fpath, "w") as f:
+                with open(dc_fpath, "w", encoding="utf-8") as f:
                     f.write(
                         calkit.resources.read_text(
                             "devcontainer",
@@ -4522,7 +4522,7 @@ async def post_project_overleaf_publication(
                 ".github", "workflows", "run-calkit.yml"
             )
             workflow_fpath = os.path.join(repo.working_dir, workflow_rel_path)
-            with open(workflow_fpath, "w") as f:
+            with open(workflow_fpath, "w", encoding="utf-8") as f:
                 f.write(calkit.resources.render_github_actions_workflow())
             repo.git.add(workflow_rel_path)
     commit_msg = (

--- a/scripts/sync-resources.py
+++ b/scripts/sync-resources.py
@@ -1,15 +1,25 @@
 #!/usr/bin/env python3
-"""Generate calkit/resources/devcontainer/devcontainer.json.
+"""Generate the derived files under calkit/resources.
 
-The dev container's VS Code customizations are derived from the shared VS Code
-config in calkit/resources/vscode, so the settings a project gets from
-``calkit update vscode-config`` and the ones it gets inside a container can't
-drift apart. Edit calkit/resources/vscode/*.json or
-calkit/resources/devcontainer/base.json, then run this
-(``make sync-resources``, or just ``make format``).
+Two things get generated here, both so a single source of truth stays
+editable where it makes sense to read it:
+
+- The dev container's VS Code customizations come from the shared VS Code
+  config in calkit/resources/vscode, so the settings a project gets from
+  ``calkit update vscode-config`` and the ones it gets inside a container
+  can't drift apart.
+- The example workflow is bundled from actions/run/example.yml, which lives
+  next to
+  the action it calls, but has to ship inside the package for
+  ``calkit update github-actions`` to install it without a download. The same
+  file fills in the snippet in actions/run/README.md.
+
+Edit the sources, then run this (``make sync-resources``, or just
+``make format``).
 """
 
 import json
+import shutil
 import sys
 from pathlib import Path
 
@@ -17,16 +27,37 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from calkit.resources import (  # noqa: E402
     DEVCONTAINER_FNAME,
+    GITHUB_ACTIONS_FNAME,
     get_dir,
     render_devcontainer_spec,
 )
 
+SNIPPET_START = "<!-- snippet:example.yml:start -->"
+SNIPPET_END = "<!-- snippet:example.yml:end -->"
+
 
 def main() -> int:
-    out_path = Path(get_dir()) / "devcontainer" / DEVCONTAINER_FNAME
+    repo_dir = Path(__file__).parent.parent
+    resources_dir = Path(get_dir())
+    out_path = resources_dir / "devcontainer" / DEVCONTAINER_FNAME
     spec = render_devcontainer_spec()
     out_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
     print(f"Wrote {out_path}")
+    workflow_path = repo_dir / "actions" / "run" / GITHUB_ACTIONS_FNAME
+    workflow_out = resources_dir / "github-actions" / GITHUB_ACTIONS_FNAME
+    workflow_out.parent.mkdir(exist_ok=True)
+    shutil.copyfile(workflow_path, workflow_out)
+    print(f"Wrote {workflow_out}")
+    # Fill in the workflow snippet in the action's README
+    readme_path = repo_dir / "actions" / "run" / "README.md"
+    readme = readme_path.read_text(encoding="utf-8")
+    start = readme.index(SNIPPET_START)
+    end = readme.index(SNIPPET_END, start)
+    workflow = workflow_path.read_text(encoding="utf-8").rstrip()
+    snippet = f"{SNIPPET_START}\n\n```yaml\n{workflow}\n```\n\n"
+    readme = readme[:start] + snippet + readme[end:]
+    readme_path.write_text(readme, encoding="utf-8")
+    print(f"Wrote {readme_path}")
     return 0
 
 

--- a/scripts/sync-resources.py
+++ b/scripts/sync-resources.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Generate calkit/resources/devcontainer/devcontainer.json.
+
+The dev container's VS Code customizations are derived from the shared VS Code
+config in calkit/resources/vscode, so the settings a project gets from
+``calkit update vscode-config`` and the ones it gets inside a container can't
+drift apart. Edit calkit/resources/vscode/*.json or
+calkit/resources/devcontainer/base.json, then run this
+(``make sync-resources``, or just ``make format``).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from calkit.resources import (  # noqa: E402
+    DEVCONTAINER_FNAME,
+    get_dir,
+    render_devcontainer_spec,
+)
+
+
+def main() -> int:
+    out_path = Path(get_dir()) / "devcontainer" / DEVCONTAINER_FNAME
+    spec = render_devcontainer_spec()
+    out_path.write_text(json.dumps(spec, indent=2) + "\n", encoding="utf-8")
+    print(f"Wrote {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Trying to keep tighter integration with these project resources, and there might be more.

## TODO

- [x] Bring in GitHub Actions
- [x] Deprecation notice in run action
- [x] Archive devcontainer repo
- [x] Grant access for this repo to push to ghcr devcontainer package
- [x] Archive vscode-config repo
- [x] Ensure `calkit update github-actions` is self-healing and updates the action version to the package version