### PR TITLE
fix(vscode): remove redundant 'update notebook' subprocess check

### DIFF
--- a/vscode-ext/src/extension.ts
+++ b/vscode-ext/src/extension.ts
@@ -1419,16 +1419,6 @@ async function ensureCalkitCliReady(): Promise<void> {
       return;
     }
 
-    const hasNotebookUpdate = await hasUpdateNotebookCommand(workspaceRoot);
-    if (!hasNotebookUpdate) {
-      await promptCalkitInstallOrUpgrade({
-        mode: "upgrade",
-        title: "Calkit CLI is too old for this extension",
-        message: `Detected Calkit ${installedVersion}, but this extension requires at least ${minimumVersion} with 'calkit update notebook'.`,
-      });
-      return;
-    }
-
     if (compareSemver(installedVersion, minimumVersion) < 0) {
       await promptCalkitInstallOrUpgrade({
         mode: "upgrade",
@@ -1481,20 +1471,6 @@ function compareSemver(a: string, b: string): number {
     }
   }
   return 0;
-}
-
-async function hasUpdateNotebookCommand(
-  workspaceRoot?: string,
-): Promise<boolean> {
-  try {
-    await execFileAsync("calkit", ["update", "notebook", "--help"], {
-      cwd: workspaceRoot,
-      timeout: 5_000,
-    });
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 async function promptCalkitInstallOrUpgrade(options: {


### PR DESCRIPTION
Fixes #1551

## Problem
The VS Code extension shows a false "requires at least 0.41.15 with 'calkit update notebook'" upgrade prompt even when the installed Calkit CLI is newer than the minimum (e.g. 0.43.1).

## Root cause
`ensureCalkitCliReady` runs two gates:
1. A `compareSemver(installedVersion, minimumVersion)` check — the authoritative version gate.
2. A redundant `hasUpdateNotebookCommand` subprocess check that runs `calkit update notebook --help`.

The subprocess check can fail for reasons unrelated to version (PATH, cwd, transient errors), which triggers the false "too old" prompt. The `update notebook` command has existed since v0.41.15 (the minimum), so the version comparison alone is sufficient.

## Fix
Remove the redundant subprocess check and its now-unused helper, relying on the version comparison as the single gate.