### PR TITLE
fix(hub): highlight Apps in sidebar on app sub-routes

### DIFF
--- a/hub/frontend/src/components/Common/SidebarItems.tsx
+++ b/hub/frontend/src/components/Common/SidebarItems.tsx
@@ -107,6 +107,10 @@ const SidebarItems = ({ onClose, basePath }: SidebarItemsProps) => {
       return null
     }
 
+    // The Apps section has sub-routes (/apps/<appName>), so it should stay
+    // highlighted on any of them, not just the exact /apps path.
+    const isApps = path === "/apps"
+
     return (
       <Flex
         key={title}
@@ -116,7 +120,7 @@ const SidebarItems = ({ onClose, basePath }: SidebarItemsProps) => {
         search={currentRef ? ({ ref: currentRef } as any) : undefined}
         w="100%"
         p={2}
-        activeOptions={{ exact: true, includeSearch: false }}
+        activeOptions={{ exact: !isApps, includeSearch: false }}
         activeProps={{
           style: {
             background: bgActive,


### PR DESCRIPTION
Fixes #1550

## Problem
The **Apps** item in the project sidebar is not highlighted when viewing a specific app page (e.g. `/apps/my-app`).

## Root cause
`SidebarItems.tsx` uses `activeOptions={{ exact: true }}` for every nav item. The Apps section is the only one with sub-routes (`/apps/<appName>`), so on a specific app page the path is not exactly `/apps` and the item loses its highlight.

## Fix
Set `exact: false` for the Apps item only, so it stays highlighted on any `/apps/*` path while all other items keep exact matching.

Verified with `tsc --noEmit` (passes).