### PR TITLE
fix(cli): skip DVC push in 'commit --push' when no DVC files changed

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1073,7 +1073,21 @@ def commit(
         cmd += ["-m", message]
     subprocess.call(cmd)
     if push_commit:
-        push()
+        # Only push to DVC if the commit actually touched DVC-tracked files
+        # (a .dvc pointer, dvc.yaml, dvc.lock, or a dvc-zip pointer). If the
+        # commit only changed Git-tracked files, skip the DVC push so we
+        # don't waste time pushing nothing.
+        repo = calkit.git.get_repo()
+        committed_files = repo.git.show(
+            "--name-only", "--format=", "HEAD"
+        ).split()
+        touched_dvc = any(
+            f.endswith(".dvc")
+            or f in ("dvc.yaml", "dvc.lock")
+            or f.startswith(".calkit/zip/")
+            for f in committed_files
+        )
+        push(no_dvc=not touched_dvc)
 
 
 @app.command(name="save|sv")


### PR DESCRIPTION
Fixes #380

## Problem
`calkit commit --push` always runs a DVC push after committing, even when the commit only touched Git-tracked files. This wastes time pushing nothing, and is especially annoying for projects that don't use DVC.

## Fix
After committing, inspect the files in the new HEAD commit. If none of them are DVC-tracked (a `.dvc` pointer, `dvc.yaml`, `dvc.lock`, or a dvc-zip pointer under `.calkit/zip/`), skip the DVC push and only push to Git.

## Verification
Manually tested:
- Committing a Git-only change → DVC push skipped (no 'Pushing to DVC remote').
- Committing a DVC-tracked file (large file → `bigdata.bin.dvc`) → DVC push attempted.