### PR TITLE
Improve repo cache warming with shared read-only clones

### DIFF
--- a/.github/workflows/deploy-hub-production.yml
+++ b/.github/workflows/deploy-hub-production.yml
@@ -107,6 +107,17 @@ jobs:
           fetch-depth: 0
       - run: docker compose -f docker-compose.yml --project-name ${{ vars.STACK_NAME }} build
       - run: docker compose -f docker-compose.yml --project-name ${{ vars.STACK_NAME }} up -d --remove-orphans
+      # `up -d` doesn't recreate a container when only its bind-mounted
+      # config changed, so Prometheus and Alloy are reloaded (SIGHUP, which
+      # avoids a scrape gap) and Loki and Grafana restarted (they don't
+      # reload).
+      - name: Reload bind-mounted configs
+        # Up but blind is worth a warning, not a failed deploy.
+        run: |
+          dc() { docker compose -f docker-compose.yml --project-name "$STACK_NAME" "$@"; }
+          try() { "$@" || echo "::warning::Config reload failed: $*"; }
+          try dc kill -s HUP prometheus alloy
+          try dc restart grafana loki
       - name: Verify the deployed version
         # The image derives its version from the Git tags at build time,
         # which has silently gone wrong before: the build reused a wheel

--- a/.github/workflows/deploy-hub-staging.yml
+++ b/.github/workflows/deploy-hub-staging.yml
@@ -78,3 +78,14 @@ jobs:
           fetch-depth: 0
       - run: docker compose -f docker-compose.yml --project-name ${{ vars.STACK_NAME }} build
       - run: docker compose -f docker-compose.yml --project-name ${{ vars.STACK_NAME }} up -d --remove-orphans
+      # `up -d` doesn't recreate a container when only its bind-mounted
+      # config changed, so Prometheus and Alloy are reloaded (SIGHUP, which
+      # avoids a scrape gap) and Loki and Grafana restarted (they don't
+      # reload).
+      - name: Reload bind-mounted configs
+        # Up but blind is worth a warning, not a failed deploy.
+        run: |
+          dc() { docker compose -f docker-compose.yml --project-name "$STACK_NAME" "$@"; }
+          try() { "$@" || echo "::warning::Config reload failed: $*"; }
+          try dc kill -s HUP prometheus alloy
+          try dc restart grafana loki

--- a/.github/workflows/test-hub.yml
+++ b/.github/workflows/test-hub.yml
@@ -148,6 +148,11 @@ jobs:
       - run: cp .env.example .env
       - run: docker compose build
       - run: docker compose down -v --remove-orphans
+      # The container's own `npm install` would otherwise run inside the
+      # window "Wait for services" is timing, which is what made that step
+      # fail on a slow runner.
+      - name: Install frontend dependencies in the dev container
+        run: docker compose run --rm --no-deps frontend npm ci
       - run: docker compose --profile objects up -d
       - name: Wait for services
         run: |
@@ -160,6 +165,10 @@ jobs:
       - name: Run Playwright tests
         run: npx playwright test
         working-directory: hub/frontend
+      # Logs are otherwise torn down with the runner.
+      - name: Show container logs
+        if: failure()
+        run: docker compose logs --no-color --tail 200
       - name: Tear down
         if: always()
         run: docker compose down -v --remove-orphans

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,5 @@ respectively.
 
 Never create `helpers` or `utils` modules or packages--tight coupling and
 low cohesion architecture.
+
+Don't be verbose in comments. One sentence is usually fine.

--- a/hub/Makefile
+++ b/hub/Makefile
@@ -18,8 +18,27 @@ export HUB_VERSION ?= $(shell git describe --tags --match 'hub/v*' --always 2>/d
 tex-engine: ## Download the TeX Live bundles for the LaTeX editor (idempotent).
 	@bash frontend/scripts/download-tex-engine.sh
 
+# A `up` that fails partway (a port already bound, most often) can leave
+# containers running but attached to no network, which every log reports as
+# a healthy start and every client as a dead service.
+.PHONY: fix-unattached
+fix-unattached: ## Recreate containers left with no network by a failed up.
+	@broken=""; \
+	for s in $$(${DOCKER_COMPOSE_DEV} ps --services --status running); do \
+		cid=$$(${DOCKER_COMPOSE_DEV} ps -q $$s); \
+		[ -n "$$cid" ] || continue; \
+		ip=$$(docker inspect $$cid \
+			--format '{{range .NetworkSettings.Networks}}{{.IPAddress}} {{end}}' \
+			| tr -d ' '); \
+		[ -n "$$ip" ] || broken="$$broken $$s"; \
+	done; \
+	if [ -n "$$broken" ]; then \
+		echo "Recreating unattached containers:$$broken"; \
+		${DOCKER_COMPOSE_DEV} up -d --force-recreate $$broken; \
+	fi
+
 .PHONY: dev
-dev: tex-engine ## Start up all containers for development.
+dev: tex-engine fix-unattached ## Start up all containers for development.
 	${DOCKER_COMPOSE_DEV} up
 
 .PHONY: api-dev

--- a/hub/backend/app/api/routes/orgs.py
+++ b/hub/backend/app/api/routes/orgs.py
@@ -15,7 +15,12 @@ from sqlmodel import Field, SQLModel, select
 import app.stripe
 from app.api.deps import CurrentUser, CurrentUserOptional, SessionDep
 from app.config import settings
-from app.core import INVALID_ACCOUNT_NAMES, utcnow
+from app.core import (
+    ACCOUNT_NAME_RULE,
+    INVALID_ACCOUNT_NAMES,
+    account_name_is_valid,
+    utcnow,
+)
 from app.models import (
     ROLE_IDS,
     Account,
@@ -137,6 +142,8 @@ def post_org(
     org_name = (req.name or req.github_name).lower()
     if org_name in INVALID_ACCOUNT_NAMES:
         raise HTTPException(422, "Invalid account name")
+    if not account_name_is_valid(org_name):
+        raise HTTPException(422, ACCOUNT_NAME_RULE)
     if get_org_from_db(org_name=org_name, session=session) is not None:
         raise HTTPException(400, "This org already exists")
     token = get_github_token(session=session, user=current_user)

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -6587,7 +6587,7 @@ def get_project_overleaf_sync_status(
         min_access_level="read",
     )
     repo = get_repo(project=project, user=current_user, session=session)
-    ck_info = get_ck_info_from_repo(repo)
+    ck_info = get_ck_info_from_repo(repo, read_only=True)
     sync_info = calkit.overleaf.get_sync_info(
         wdir=repo.working_dir, ck_info=deepcopy(ck_info)
     )

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -2628,6 +2628,69 @@ class _FigureContext(NamedTuple):
     dvc_lock: dict[str, Any]
 
 
+def _looks_like_figure(path: str) -> bool:
+    """Whether ``path`` is a file we'd show as a figure without being told."""
+    parts = path.split("/")
+    if any(p.startswith(".") for p in parts):
+        return False
+    ext = "." + parts[-1].rsplit(".", 1)[-1] if "." in parts[-1] else ""
+    dir_parts = [p.lower() for p in parts[:-1]]
+    return ext.lower() in FIGURE_EXTS and any(
+        d in FIGURE_DIRS for d in dir_parts
+    )
+
+
+def _tree_figure_paths(repo: git.Repo, ref: str | None) -> list[str]:
+    """Figure-looking paths in the tree, including via `.dvc` pointers.
+
+    A full tree walk plus a YAML parse of every `.dvc` file, which is tens
+    of milliseconds on a large project and the same answer for every viewer
+    of a commit, so it is cached against that commit and warmed on push.
+    """
+    sha = resolve_commit_sha(repo, ref)
+    key = cache.make_key("figpaths", sha) if sha else None
+    if key is not None:
+        cached = cache.get_json(key)
+        if isinstance(cached, list):
+            return cached
+    paths: list[str] = []
+    try:
+        commit = repo.commit(ref) if ref else repo.head.commit
+        for blob in commit.tree.traverse():
+            if blob.type != "blob":  # type: ignore[union-attr]
+                continue
+            blob_path: str = blob.path  # type: ignore[union-attr]
+            if _looks_like_figure(blob_path):
+                paths.append(blob_path)
+            # Figures stored via standalone `.dvc` pointer files (tracked
+            # with `dvc add`, not via a pipeline stage).
+            if not blob_path.endswith(".dvc"):
+                continue
+            actual_path = blob_path[:-4]
+            try:
+                dvc_data = yaml.safe_load(blob.data_stream.read())  # type: ignore[union-attr]
+                outs = (
+                    dvc_data.get("outs")
+                    if isinstance(dvc_data, dict)
+                    else None
+                )
+                out = outs[0] if isinstance(outs, list) and outs else None
+                out_path = out.get("path") if isinstance(out, dict) else None
+                if isinstance(out_path, str) and out_path:
+                    actual_path = os.path.normpath(
+                        os.path.join(os.path.dirname(blob_path), out_path)
+                    )
+            except Exception:
+                pass
+            if actual_path and _looks_like_figure(actual_path):
+                paths.append(actual_path)
+    except Exception:
+        return paths
+    if key is not None:
+        cache.set_json(key, paths)
+    return paths
+
+
 def _discover_figures(
     project: Project,
     repo: git.Repo,
@@ -2657,54 +2720,12 @@ def _discover_figures(
         """Add `path` to figures if it looks like a figure and is not yet
         known.
         """
-        parts = path.split("/")
-        if any(p.startswith(".") for p in parts):
-            return
-        ext = "." + parts[-1].rsplit(".", 1)[-1] if "." in parts[-1] else ""
-        dir_parts = [p.lower() for p in parts[:-1]]
-        if ext.lower() in FIGURE_EXTS and any(
-            d in FIGURE_DIRS for d in dir_parts
-        ):
-            if path not in declared_paths:
-                figures.append({"path": path, "title": title_from_path(path)})
-                declared_paths.add(path)
+        if _looks_like_figure(path) and path not in declared_paths:
+            figures.append({"path": path, "title": title_from_path(path)})
+            declared_paths.add(path)
 
-    # Auto-detect figures from the repo tree
-    try:
-        commit = repo.commit(ref) if ref else repo.head.commit
-        for blob in commit.tree.traverse():
-            if blob.type != "blob":  # type: ignore[union-attr]
-                continue
-            blob_path: str = blob.path  # type: ignore[union-attr]
-            _maybe_add_figure(blob_path)
-            # Also detect figures stored via standalone .dvc pointer files
-            # (tracked with `dvc add`, not via a DVC pipeline stage).
-            if blob_path.endswith(".dvc"):
-                try:
-                    dvc_data = yaml.safe_load(blob.data_stream.read())  # type: ignore[union-attr]
-                    outs = (
-                        dvc_data.get("outs")
-                        if isinstance(dvc_data, dict)
-                        else None
-                    )
-                    out = outs[0] if isinstance(outs, list) and outs else None
-                    out_path = (
-                        out.get("path") if isinstance(out, dict) else None
-                    )
-                    if isinstance(out_path, str) and out_path:
-                        actual_path = os.path.normpath(
-                            os.path.join(os.path.dirname(blob_path), out_path)
-                        )
-                    else:
-                        actual_path = blob_path[:-4]
-                    if actual_path:
-                        _maybe_add_figure(actual_path)
-                except Exception:
-                    actual_path = blob_path[:-4]
-                    if actual_path:
-                        _maybe_add_figure(actual_path)
-    except Exception:
-        pass
+    for path in _tree_figure_paths(repo, ref):
+        _maybe_add_figure(path)
     # Pre-compute calkit.yaml / dvc.lock metadata once for the tree so we
     # don't re-read and re-expand on every iteration.
     tree = app.projects.get_repo_tree_for_ref(repo, ref)
@@ -2781,6 +2802,7 @@ def _resolve_figures(
             .group_by(ProjectComment.artifact_path)
         ).all()
     )
+    sha = resolve_commit_sha(repo, ref)
     # Staleness is best-effort: never let it block the figure listing.
     stage_statuses = {}
     try:
@@ -2794,7 +2816,7 @@ def _resolve_figures(
             owner_name=project.owner_account_name,
             project_name=project.name,
             fs=get_object_fs(),
-            cache_token=resolve_commit_sha(repo, ref),
+            cache_token=sha,
         )
     except Exception as e:
         logger.warning(f"Failed to compute pipeline status for figures: {e}")
@@ -2812,7 +2834,26 @@ def _resolve_figures(
             fig["stage_status"] = stage_statuses[fig["stage"]].model_dump()
         return fig
 
+    def _thumb_key(path: str) -> str | None:
+        # By commit and path rather than by content hash: the content hash
+        # is only knowable once the bytes are in hand, so keying on it means
+        # downloading a full-size figure to discover we already have its
+        # thumbnail. What lives at a path in a commit never changes, so this
+        # answers before any download.
+        return cache.make_key("figthumb", sha, path) if sha else None
+
     def _resolve(fig: dict[str, Any]) -> dict[str, Any]:
+        key = _thumb_key(fig["path"]) if thumbnails else None
+        if key is not None:
+            hit = cache.get_json(key)
+            if isinstance(hit, dict) and hit.get("thumbnail"):
+                # The grid renders the thumbnail and nothing else, so the
+                # bytes it would otherwise download go unread.
+                fig["thumbnail"] = hit["thumbnail"]
+                fig["storage"] = hit.get("storage")
+                fig["content"] = None
+                fig["url"] = None
+                return _annotate(fig)
         item = app.projects.get_contents_from_tree(
             project=project,
             tree=tree,
@@ -2840,6 +2881,14 @@ def _resolve_figures(
             # The full-size bytes are what this call was avoiding sending.
             if fig.get("thumbnail"):
                 fig["content"] = None
+                if key is not None:
+                    cache.set_json(
+                        key,
+                        {
+                            "thumbnail": fig["thumbnail"],
+                            "storage": item.storage,
+                        },
+                    )
         return _annotate(fig)
 
     if not resolve_content:
@@ -8030,7 +8079,7 @@ def get_project_references(
         ref=ref,
         read_only=True,
     )
-    ck_info = get_ck_info_from_repo(repo)
+    ck_info = get_ck_info_from_repo(repo, read_only=True)
     # An empty "references:" key in calkit.yaml parses to None.
     ref_collections = ck_info.get("references") or []
     declared_paths = {

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -1559,7 +1559,7 @@ def get_project_history(
         user=current_user,
         session=session,
         ttl=FULL_HISTORY_REPO_TTL,
-        shared_read=True,
+        read_only=True,
     )
     history = get_commit_history(repo, max_count=limit + offset, ref=ref)
     return history[offset : offset + limit]
@@ -1732,7 +1732,7 @@ def get_project_file_history(
         user=current_user,
         session=session,
         ttl=FULL_HISTORY_REPO_TTL,
-        shared_read=True,
+        read_only=True,
     )
     return get_file_history(repo, path=path, max_count=limit, storage=storage)
 
@@ -1820,7 +1820,7 @@ def get_project_contents(
         session=session,
         ttl=ttl,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     return app.projects.get_contents_from_repo(
         project=project,
@@ -2004,7 +2004,7 @@ def get_project_content_paths(
         session=session,
         ttl=ttl,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     tree = app.projects.get_repo_tree_for_ref(repo, ref)
     dvc_lock_outs = app.projects.get_ck_info_and_dvc_outs_from_tree(
@@ -2455,7 +2455,7 @@ def get_project_questions(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -3289,7 +3289,7 @@ def get_project_tables(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     return _build_tables(
         project=project,
@@ -3340,7 +3340,7 @@ def get_project_results(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     return _build_results(project=project, repo=repo, ref=ref)
 
@@ -5049,7 +5049,7 @@ def get_project_publications(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     # Read declared metadata at the requested ref. get_repo only fetches a
     # ref, it does not check it out, so reading the working tree would return
@@ -5579,7 +5579,7 @@ def get_project_presentations(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     # Read declared metadata at the requested ref. get_repo only fetches a
     # ref, it does not check it out, so reading the working tree would return
@@ -6921,7 +6921,7 @@ def get_project_pipeline(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     # Read files at the requested ref rather than the live checkout, which
     # always reflects the default branch (get_repo only fetches a ref, it
@@ -8050,7 +8050,7 @@ def get_project_references(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = get_ck_info_from_repo(repo)
     # An empty "references:" key in calkit.yaml parses to None.
@@ -9660,7 +9660,7 @@ def get_project_environments(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -9783,7 +9783,7 @@ def get_project_software(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -9896,7 +9896,7 @@ def get_project_notebooks(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -10002,7 +10002,7 @@ def get_project_repro_check(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     # A pure function of the tree at this commit, and a second and a half of
     # work on a large project, so it is worked out once per commit rather
@@ -10361,7 +10361,7 @@ def get_project_showcase(
         session=session,
         ttl=ttl,
         ref=ref,
-        shared_read=True,
+        read_only=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -1292,6 +1292,7 @@ def get_project(
             session=session,
             ttl=DEFAULT_REPO_TTL,
             ref=ref,
+            read_only=True,
         )
         # Read at the requested ref. get_repo only fetches a ref, it does
         # not check it out, so get_ck_info_from_repo (working tree) would
@@ -2923,6 +2924,7 @@ def get_project_figures(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        read_only=True,
     )
     ctx = _discover_figures(project=project, repo=repo, ref=ref)
     # Filter before paging, so search covers every figure in the project
@@ -3369,6 +3371,7 @@ def get_project_figure(
         session=session,
         ttl=ttl,
         ref=ref,
+        read_only=True,
     )
     ctx = _discover_figures(project=project, repo=repo, ref=ref)
     matched = [fig for fig in ctx.figures if fig["path"] == figure_path]
@@ -4232,6 +4235,7 @@ def get_project_datasets(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        read_only=True,
     )
     project = _sync_datasets_with_db(
         ck_info=ck_info, project=project, session=session

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -9736,11 +9736,10 @@ def post_project_environment(
     repo = get_repo(
         project=project, user=current_user, session=session, ttl=None
     )
-    ck_info = app.projects.get_ck_info_for_ref(
-        project=project,
-        repo=repo,
-        ref=ref,
-    )
+    # Written back below, so it has to come through the round-trip parser
+    # and without the path normalization ``get_ck_info_for_ref`` applies:
+    # both would be silently saved into the user's calkit.yaml.
+    ck_info = app.projects.get_ck_info_from_repo(repo)
     envs = ck_info.get("environments", {})
     if req.name in envs:
         raise HTTPException(400, "Environment with same name already exists")

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -2840,7 +2840,14 @@ def _resolve_figures(
         # downloading a full-size figure to discover we already have its
         # thumbnail. What lives at a path in a commit never changes, so this
         # answers before any download.
-        return cache.make_key("figthumb", sha, path) if sha else None
+        #
+        # Scoped to the project, not just the commit: a fork shares its
+        # parent's commits but not its DVC storage, so a figure tracked by
+        # DVC is a different file at the same commit and path. Without this
+        # a public fork could be served a private parent's thumbnail.
+        if not sha or project.id is None:
+            return None
+        return cache.make_key("figthumb", str(project.id), sha, path)
 
     def _resolve(fig: dict[str, Any]) -> dict[str, Any]:
         key = _thumb_key(fig["path"]) if thumbnails else None

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -1306,7 +1306,9 @@ def get_project(
         # the difference between a few milliseconds and a quarter of a
         # second, and this request is what the whole project page waits on.
         ck_info = app.projects.get_ck_info_for_ref(
-            project=project, repo=repo, ref=ref, read_only=True
+            project=project,
+            repo=repo,
+            ref=ref,
         )
         resp.calkit_info_keys = list(ck_info.keys())
         # Read status if present
@@ -2460,8 +2462,7 @@ def get_project_questions(
         repo=repo,
         ref=ref,
         # This route only reads; the POST/PUT handlers below load their own
-        # copy through ruamel so their rewrites keep comments intact.
-        read_only=True,
+        # copy through ruamel so their rewrites keep comments intact.,
     )
     project = _sync_questions_with_db(
         ck_info=ck_info, project=project, session=session
@@ -2651,8 +2652,7 @@ def _discover_figures(
         ref=ref,
         # Discovery only reads this metadata, so skip ruamel's round-trip
         # parser; on a 42 KB calkit.yaml that is ~5 ms instead of ~78 ms,
-        # paid on every page of the listing.
-        read_only=True,
+        # paid on every page of the listing.,
     )
     figures = ck_info.get("figures", [])
     # Declared figures (from calkit.yaml) may omit a title; fill one in so
@@ -3111,7 +3111,6 @@ def _build_tables(
         project=project,
         repo=repo,
         ref=ref,
-        read_only=True,
     )
     tables: list[dict[str, Any]] = []
     known_paths: set[str] = set()
@@ -5266,7 +5265,9 @@ def get_project_publication_components(
     )
     tree = get_repo_tree_for_ref(repo, ref)
     ck_info = app.projects.get_ck_info_for_ref(
-        project=project, repo=repo, ref=ref, read_only=True
+        project=project,
+        repo=repo,
+        ref=ref,
     )
     dvc_outs = app.projects.dvc_outputs_from_tree(project=project, tree=tree)
     # Every file in the folder, from Git and from DVC
@@ -10177,7 +10178,6 @@ def get_project_apps(
         project=project,
         repo=repo,
         ref=ref,
-        read_only=True,
     )
     return _project_apps_from_ck_info(
         ck_info, owner_name=owner_name, project_name=project_name
@@ -10274,7 +10274,9 @@ def serve_project_app_file(
         )
         return RedirectResponse(base + path.strip("/"), status_code=302)
     ck_info = app.projects.get_ck_info_for_ref(
-        project=project, repo=repo, ref=git_sha, read_only=True
+        project=project,
+        repo=repo,
+        ref=git_sha,
     )
     apps = _project_apps_from_ck_info(
         ck_info, owner_name=owner_name, project_name=project_name

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -2461,8 +2461,6 @@ def get_project_questions(
         project=project,
         repo=repo,
         ref=ref,
-        # This route only reads; the POST/PUT handlers below load their own
-        # copy through ruamel so their rewrites keep comments intact.,
     )
     project = _sync_questions_with_db(
         ck_info=ck_info, project=project, session=session
@@ -2650,9 +2648,6 @@ def _discover_figures(
         project=project,
         repo=repo,
         ref=ref,
-        # Discovery only reads this metadata, so skip ruamel's round-trip
-        # parser; on a 42 KB calkit.yaml that is ~5 ms instead of ~78 ms,
-        # paid on every page of the listing.,
     )
     figures = ck_info.get("figures", [])
     # Declared figures (from calkit.yaml) may omit a title; fill one in so

--- a/hub/backend/app/api/routes/projects/core.py
+++ b/hub/backend/app/api/routes/projects/core.py
@@ -1557,6 +1557,7 @@ def get_project_history(
         user=current_user,
         session=session,
         ttl=FULL_HISTORY_REPO_TTL,
+        shared_read=True,
     )
     history = get_commit_history(repo, max_count=limit + offset, ref=ref)
     return history[offset : offset + limit]
@@ -1729,6 +1730,7 @@ def get_project_file_history(
         user=current_user,
         session=session,
         ttl=FULL_HISTORY_REPO_TTL,
+        shared_read=True,
     )
     return get_file_history(repo, path=path, max_count=limit, storage=storage)
 
@@ -1816,6 +1818,7 @@ def get_project_contents(
         session=session,
         ttl=ttl,
         ref=ref,
+        shared_read=True,
     )
     return app.projects.get_contents_from_repo(
         project=project,
@@ -1994,7 +1997,12 @@ def get_project_content_paths(
         min_access_level="read",
     )
     repo = get_repo(
-        project=project, user=current_user, session=session, ttl=ttl, ref=ref
+        project=project,
+        user=current_user,
+        session=session,
+        ttl=ttl,
+        ref=ref,
+        shared_read=True,
     )
     tree = app.projects.get_repo_tree_for_ref(repo, ref)
     dvc_lock_outs = app.projects.get_ck_info_and_dvc_outs_from_tree(
@@ -2445,6 +2453,7 @@ def get_project_questions(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -3281,6 +3290,7 @@ def get_project_tables(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     return _build_tables(
         project=project,
@@ -3331,6 +3341,7 @@ def get_project_results(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     return _build_results(project=project, repo=repo, ref=ref)
 
@@ -5039,6 +5050,7 @@ def get_project_publications(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     # Read declared metadata at the requested ref. get_repo only fetches a
     # ref, it does not check it out, so reading the working tree would return
@@ -5566,6 +5578,7 @@ def get_project_presentations(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     # Read declared metadata at the requested ref. get_repo only fetches a
     # ref, it does not check it out, so reading the working tree would return
@@ -6907,6 +6920,7 @@ def get_project_pipeline(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     # Read files at the requested ref rather than the live checkout, which
     # always reflects the default branch (get_repo only fetches a ref, it
@@ -8035,6 +8049,7 @@ def get_project_references(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     ck_info = get_ck_info_from_repo(repo)
     # An empty "references:" key in calkit.yaml parses to None.
@@ -9644,6 +9659,7 @@ def get_project_environments(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -9766,6 +9782,7 @@ def get_project_software(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -9878,6 +9895,7 @@ def get_project_notebooks(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,
@@ -9983,6 +10001,7 @@ def get_project_repro_check(
         session=session,
         ttl=DEFAULT_REPO_TTL,
         ref=ref,
+        shared_read=True,
     )
     # A pure function of the tree at this commit, and a second and a half of
     # work on a large project, so it is worked out once per commit rather
@@ -10340,6 +10359,7 @@ def get_project_showcase(
         session=session,
         ttl=ttl,
         ref=ref,
+        shared_read=True,
     )
     ck_info = app.projects.get_ck_info_for_ref(
         project=project,

--- a/hub/backend/app/core.py
+++ b/hub/backend/app/core.py
@@ -4,6 +4,7 @@ import csv
 import logging
 import os
 import posixpath
+import re
 import threading
 from datetime import UTC, datetime
 from typing import Any
@@ -188,6 +189,37 @@ INVALID_ACCOUNT_NAMES = [
 # own name as a personal account while hub operators can still create
 # an org under it
 ORG_ONLY_ACCOUNT_NAMES = ["calkit"]
+
+# What an account may be named: GitHub's own rule for usernames, which also
+# happens to be what is safe as a single directory under CLONE_ROOT. Without
+# it ".." and "_shared" are both a signup away, and both name a directory
+# that means something else (see ``app.git._clone_dir_segment``).
+ACCOUNT_NAME_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+ACCOUNT_NAME_RULE = (
+    "Account names may use lowercase letters, numbers and single hyphens, "
+    "and must start and end with a letter or number."
+)
+
+
+def account_name_is_valid(name: str) -> bool:
+    """Whether ``name`` is allowed as an account name."""
+    return bool(
+        name
+        and 2 <= len(name) <= 64
+        and ACCOUNT_NAME_RE.fullmatch(name)
+        and name not in INVALID_ACCOUNT_NAMES
+    )
+
+
+def sanitize_account_name(name: str) -> str:
+    """Coerce ``name`` into the account-name shape, for names nobody chose.
+
+    A name derived from an email address or a display name is not the
+    user's choice, so it is cleaned up rather than rejected. A name they
+    typed is checked instead -- see ``account_name_is_valid``.
+    """
+    cleaned = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return cleaned[:64].rstrip("-")
 
 
 def utcnow() -> datetime:

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -181,6 +181,61 @@ def get_remote_head_sha(
     return sha
 
 
+# Where the one checkout everybody reads from lives, under CLONE_ROOT. Not a
+# possible account name (see INVALID_ACCOUNT_NAMES), and the leading
+# underscore keeps it from colliding with one anyway.
+SHARED_READER_DIR = "_shared"
+
+
+def is_shared_read_checkout(repo: git.Repo) -> bool:
+    """Whether this repo is the checkout everybody reads from."""
+    return (os.sep + SHARED_READER_DIR + os.sep) in os.path.abspath(
+        str(repo.working_dir)
+    )
+
+
+def refuse_if_shared(repo: git.Repo) -> None:
+    """Stop a write that has landed on the shared checkout.
+
+    Reads share one copy per project; writes each get their own. Committing
+    in the shared one would author it in a tree other people are reading,
+    and push it under whichever credentials that copy happens to hold. A
+    caller that ends up here asked for a shared read and then tried to
+    write, which is a bug in the caller rather than anything a user did.
+    """
+    if is_shared_read_checkout(repo):
+        raise HTTPException(
+            500, "Refusing to write to the shared read-only checkout"
+        )
+
+
+def _shared_read_token(project: Project) -> tuple[bool, str | None]:
+    """Whether this project can be read from one shared checkout, and how.
+
+    A public repo clones with no credentials at all. A private one needs a
+    token, and the App installation token is the right one: it belongs to
+    the project rather than to whoever happened to ask first, so the
+    checkout it produces isn't tied to a user who may later lose access.
+
+    Returns ``(False, None)`` when neither applies, and the caller keeps its
+    own checkout as before.
+    """
+    if project.is_public:
+        return True, None
+    gh_owner, gh_repo = (
+        project.github_repo.split("/", 1)
+        if project.github_repo
+        else (project.owner_github_name, project.name)
+    )
+    try:
+        return True, github.get_app_installation_token(gh_owner, gh_repo)
+    except (github.GitHubAppNotConfigured, HTTPException) as e:
+        logger.info(
+            f"No shared checkout for private {gh_owner}/{gh_repo}: {e}"
+        )
+        return False, None
+
+
 def get_repo(
     project: Project,
     user: User | None,
@@ -188,17 +243,36 @@ def get_repo(
     ttl: int | None = None,
     fresh=False,
     ref: str | None = None,
+    shared_read: bool = False,
 ) -> git.Repo:
     """Ensure that the repo exists and is ready for operating upon for the user.
 
     Handles concurrency in case multiple API calls request the repo
     simultaneously. If TTL is None, the latest version is always fetched.
+
+    ``shared_read`` asks for the checkout everybody reads from rather than
+    this user's own. What a commit contains is the same whoever is looking,
+    so a project needs one copy for reading, not one per viewer -- and one
+    that stays warm for the next person instead of being cloned again.
+
+    It is opt-in, and deliberately so: the shared checkout must never be
+    written to, since a commit made there would be authored in a tree other
+    people are reading. A caller that doesn't ask for it gets its own
+    checkout exactly as before, so the cost of missing one is a slow read
+    rather than a wrong write.
     """
     owner_name = project.owner_github_name
     project_name = project.name
+    shared_token: str | None = None
+    if shared_read:
+        shared_read, shared_token = _shared_read_token(project)
     # Add the file to the repo(s) -- we may need to clone it.
     # Ref-based reads should not mutate this working tree checkout.
-    if user is not None:
+    if shared_read:
+        base_dir = os.path.join(
+            settings.CLONE_ROOT, SHARED_READER_DIR, owner_name, project_name
+        )
+    elif user is not None:
         # github_username is None for GitHub-less users; fall back to the
         # (always-present, unique) account name for a stable temp path.
         user_dir = user.github_username or user.account.name
@@ -225,7 +299,13 @@ def get_repo(
             os.remove(updated_fpath)
     # Clone the repo if it doesn't exist -- it will be in a "repo" dir
     access_token: str | None = None
-    if user is not None:
+    if shared_read:
+        # The shared checkout belongs to the project, not to whoever asked
+        # for it, so it carries the project's credentials and never a
+        # user's. Nothing here is authorized by this: the caller has
+        # already been through get_project.
+        access_token = shared_token
+    elif user is not None:
         if user.account.github_name is not None:
             # GitHub user: operate with their personal token.
             logger.info(f"Getting {user.email}'s token for Git operations")
@@ -543,7 +623,7 @@ def get_repo(
     # have stored the literal string "None" as the committer, so we
     # re-run on every refresh to repair that -- but not on every cached
     # read, which would be pure overhead.
-    if user is not None and did_refresh:
+    if user is not None and did_refresh and not shared_read:
         _configure_committer(repo, user, session=session)
     if did_refresh:
         record_project_update(project, repo, session)
@@ -612,6 +692,7 @@ def _configure_committer(
     -> ``email`` so we never pass ``None`` (which GitPython would stringify
     to "None").
     """
+    refuse_if_shared(repo)
     email = user.email or f"{user.github_username}@users.noreply.github.com"
     if not user.full_name and session is not None:
         detected = _detect_full_name_from_history(repo, email)

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -182,27 +182,22 @@ def get_remote_head_sha(
     return sha
 
 
-# Where the one checkout everybody reads from lives, under CLONE_ROOT. A
-# GitHub name can hold only letters, digits and hyphens, so no owner can
-# ever be spelled this way; ``_clone_dir_segment`` keeps the per-user
-# directories out of it too, since an account name is not so constrained.
+# Where the one checkout everybody reads from lives, under CLONE_ROOT. No
+# GitHub name can be spelled this way, and ``_clone_dir_segment`` keeps the
+# per-user directories out of it too.
 SHARED_READER_DIR = "_shared"
 
 
 def _clone_dir_segment(name: str) -> str:
     """Make ``name`` safe to use as one directory under ``CLONE_ROOT``.
 
-    The per-user checkout directory is named after the requester, and an
-    account name is whatever they typed at signup -- it is unique and
-    non-empty, and nothing else. A name of ``..`` would put their checkouts
-    outside ``CLONE_ROOT`` entirely, and one of ``_shared`` would put their
-    *writable* checkouts on top of the tree every reader of that project
-    reads from. Both are one signup away, so neither is left to convention.
+    An account name is whatever someone typed at signup, so ``..`` (outside
+    CLONE_ROOT) and ``_shared`` (on top of the tree everyone reads) are both
+    one signup away.
     """
     segment = name.replace(os.sep, "_").replace("/", "_")
     if segment in ("", ".", "..", SHARED_READER_DIR):
-        # Distinct from the name it stands in for, and still stable for
-        # this account, so the checkout is found again next time.
+        # Stable, so the account finds its checkout again next time.
         segment = "acct_" + hashlib.sha256(name.encode()).hexdigest()[:16]
     return segment
 
@@ -217,12 +212,8 @@ def is_shared_read_checkout(repo: git.Repo) -> bool:
 def refuse_if_shared(repo: git.Repo) -> None:
     """Stop a write that has landed on the shared checkout.
 
-    Reads share one copy per project; writes each get their own. Committing
-    in the shared one would author it in a tree other people are reading,
-    and push it under whichever credentials that copy happens to hold. A
-    caller that ends up here asked ``get_repo`` for a read-only repo and
-    then wrote to it, which is a bug in the caller rather than anything
-    a user did.
+    Committing there would author it in a tree other people are reading, and
+    push it under whatever credentials that copy holds.
     """
     if is_shared_read_checkout(repo):
         raise HTTPException(
@@ -230,12 +221,9 @@ def refuse_if_shared(repo: git.Repo) -> None:
         )
 
 
-# Hooks that make the shared checkout refuse to be written to, from inside
-# Git itself. `pre-commit` is the one that matters -- a commit there would be
-# authored in a tree other people are reading -- and `pre-push` goes with it
-# because the shared checkout is the one carrying the project's own
-# credentials, so a push from it is the version of that mistake that leaves
-# the machine.
+# Refuse writes to the shared checkout from inside Git itself. `pre-push`
+# goes with `pre-commit` because that copy carries the project's own
+# credentials.
 _SHARED_HOOKS = ("pre-commit", "pre-push")
 _SHARED_HOOK_SCRIPT = (
     "#!/bin/sh\n"
@@ -249,23 +237,16 @@ _SHARED_HOOK_SCRIPT = (
 def _install_read_only_hooks(repo_dir: str) -> None:
     """Make ``repo_dir`` refuse commits and pushes at the Git level.
 
-    ``refuse_if_shared`` catches a caller that asked ``get_repo`` for a
-    read-only repo and then wrote to it, but only where we thought to call
-    it, and only for writes that go through our own helpers. The hooks sit
-    under all of it: anything reaching ``git commit`` in this tree fails,
-    whether it came through GitPython, a subprocess, or DVC.
-
-    Best effort by design -- a checkout we cannot write a hook into is
-    still readable, and refusing to serve it would turn a hardening measure
-    into an outage.
+    ``refuse_if_shared`` only catches writes going through our own helpers;
+    these catch anything reaching ``git commit``. Best effort: a checkout we
+    can't write a hook into is still readable.
     """
     hooks_dir = os.path.join(repo_dir, ".git", "hooks")
     try:
         os.makedirs(hooks_dir, exist_ok=True)
         for name in _SHARED_HOOKS:
             fpath = os.path.join(hooks_dir, name)
-            # Written once per checkout, so the common case is two stats.
-            # An existing hook that isn't executable is one Git ignores.
+            # A hook that isn't executable is one Git ignores.
             if os.path.isfile(fpath) and os.access(fpath, os.X_OK):
                 continue
             with open(fpath, "w") as f:
@@ -278,13 +259,9 @@ def _install_read_only_hooks(repo_dir: str) -> None:
 def _shared_read_token(project: Project) -> tuple[bool, str | None]:
     """Whether this project can be read from one shared checkout, and how.
 
-    A public repo clones with no credentials at all. A private one needs a
-    token, and the App installation token is the right one: it belongs to
-    the project rather than to whoever happened to ask first, so the
-    checkout it produces isn't tied to a user who may later lose access.
-
-    Returns ``(False, None)`` when neither applies, and the caller keeps its
-    own checkout as before.
+    A public repo needs no credentials; a private one takes the App
+    installation token, which belongs to the project rather than to whoever
+    asked first. Returns ``(False, None)`` when neither applies.
     """
     if project.is_public:
         return True, None
@@ -317,22 +294,15 @@ def get_repo(
     simultaneously. If TTL is None, the latest version is always fetched.
 
     ``read_only`` promises the caller will only read, which lets every
-    reader of a project share one checkout instead of cloning their own.
-    What a commit contains is the same whoever is looking, so a project
-    needs one copy for reading, not one per viewer -- and one that stays
-    warm for the next person rather than being cloned again.
-
-    It is opt-in, and deliberately so: a caller that doesn't ask for it
-    gets its own checkout exactly as before, so the cost of missing one is
-    a slow read rather than a wrong write. Breaking the promise is caught
-    rather than trusted -- see ``refuse_if_shared``.
+    reader of a project share one warm checkout instead of cloning their
+    own. Opt-in, so the cost of missing one is a slow read rather than a
+    wrong write; breaking the promise is caught by ``refuse_if_shared``.
     """
     owner_name = project.owner_github_name
     project_name = project.name
     shared_token: str | None = None
-    # Read-only is what the caller asks for; sharing is how it's answered,
-    # and a private repo the App isn't installed on can't be answered that
-    # way at all. Those fall back to a per-user checkout, still read-only.
+    # A private repo the App isn't installed on falls back to a per-user
+    # checkout, still read-only.
     shared = False
     if read_only:
         shared, shared_token = _shared_read_token(project)
@@ -372,10 +342,8 @@ def get_repo(
     # Clone the repo if it doesn't exist -- it will be in a "repo" dir
     access_token: str | None = None
     if shared:
-        # The shared checkout belongs to the project, not to whoever asked
-        # for it, so it carries the project's credentials and never a
-        # user's. Nothing here is authorized by this: the caller has
-        # already been through get_project.
+        # The project's credentials, never a user's. This authorizes
+        # nothing; the caller has already been through get_project.
         access_token = shared_token
     elif user is not None:
         if user.account.github_name is not None:
@@ -542,9 +510,8 @@ def get_repo(
             headers={"Retry-After": "5"},
         )
     if shared:
-        # Here rather than next to the clone so it also covers the checkouts
-        # that already exist, and the TTL fast path that returns below
-        # without ever going near the clone code.
+        # Here rather than next to the clone so it covers existing checkouts
+        # and the TTL fast path that returns below.
         _install_read_only_hooks(repo_dir)
     last_updated = os.path.getmtime(updated_fpath)
     did_refresh = newly_cloned
@@ -837,10 +804,8 @@ def get_ck_info(
 ) -> dict:
     """Load the calkit.yaml file contents into a dictionary.
 
-    ``read_only`` promises the caller only inspects the result and never
-    writes it back, which lets both the checkout and the parser take their
-    cheap forms: the shared read-only clone (see ``get_repo``) and the C
-    loader rather than ruamel's round-trip one.
+    ``read_only`` promises the caller never writes the result back, which
+    buys both the shared checkout and the fast parser.
     """
     repo = get_repo(
         project=project,
@@ -1692,23 +1657,17 @@ class RepoTree(ABC):
 class WorkingTree(RepoTree):
     """RepoTree backed by a live filesystem checkout.
 
-    Unlike ``GitTree``, which can only name objects that are actually in a
-    commit, this reaches the filesystem -- so "the path is inside the repo"
-    is a claim to check rather than one to assume. Paths arrive here from
-    ``calkit.yaml`` and from request URLs, and every project's checkout sits
-    at a predictable path beside every other project's under ``CLONE_ROOT``
-    (``_shared/<owner>/<project>/repo`` most predictably of all). A path
-    that walks out of this repo walks straight into someone else's, whether
-    or not the reader can see that project.
+    Unlike ``GitTree``, this reaches the filesystem, and paths arrive here
+    from ``calkit.yaml`` and from request URLs. Every project's checkout
+    sits beside every other one under ``CLONE_ROOT``, so a path that walks
+    out of this repo walks into someone else's.
     """
 
     def __init__(self, root: str) -> None:
         self._root = root
         self._root_norm = os.path.normpath(root)
-        # Resolved once here rather than per call, and kept apart from the
-        # normalized form: CLONE_ROOT itself may be a symlink, so a resolved
-        # path has to be compared against a resolved root or every read in
-        # the checkout looks like it escapes.
+        # Kept apart from the normalized form: CLONE_ROOT may itself be a
+        # symlink, so a resolved path needs a resolved root to compare to.
         try:
             self._root_real = os.path.realpath(root)
         except (OSError, ValueError):
@@ -1722,8 +1681,7 @@ class WorkingTree(RepoTree):
         """Absolute path for ``path``, or ``None`` if it leaves the checkout.
 
         Lexical, so it costs no syscalls in the directory listings that call
-        it once per entry. Symlinks pointing out of the tree are a separate
-        question, answered by ``is_safe_symlink`` and by ``read_bytes``.
+        it once per entry; symlinks are ``is_safe_symlink``'s job.
         """
         if not path:
             return self._root
@@ -1760,9 +1718,8 @@ class WorkingTree(RepoTree):
 
     def read_bytes(self, path: str) -> bytes:
         fpath = self._abs(path)
-        # Content is what actually leaves the machine, so this one pays for
-        # a resolved check too: a symlink out of the tree reads whatever it
-        # points at, and `..` is only the obvious way to spell that.
+        # Content is what leaves the machine, so this one also pays for a
+        # resolved check: `..` isn't the only way out of the tree.
         if fpath is None or not self.is_safe_symlink(path):
             raise HTTPException(404)
         with open(fpath, "rb") as f:

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -1677,6 +1677,11 @@ class WorkingTree(RepoTree):
     def _within(root: str, candidate: str) -> bool:
         return candidate == root or candidate.startswith(root + os.sep)
 
+    @staticmethod
+    def _is_repo_internal(path: str) -> bool:
+        """Whether ``path`` names anything under a ``.git`` directory."""
+        return ".git" in path.replace(os.sep, "/").split("/")
+
     def _abs(self, path: str | None) -> str | None:
         """Absolute path for ``path``, or ``None`` if it leaves the checkout.
 
@@ -1685,6 +1690,12 @@ class WorkingTree(RepoTree):
         """
         if not path:
             return self._root
+        # `.git` is the one thing this tree can see that ``GitTree`` cannot,
+        # and it is repo plumbing rather than project content: the remote
+        # URL, and whatever a legacy clone embedded in it.
+        if self._is_repo_internal(path):
+            logger.warning(f"Refusing to read repo internals: {path!r}")
+            return None
         full = os.path.join(self._root, path)
         if not self._within(self._root_norm, os.path.normpath(full)):
             logger.warning(f"Refusing path outside {self._root}: {path!r}")
@@ -1712,7 +1723,14 @@ class WorkingTree(RepoTree):
         if fpath is None:
             return False
         try:
-            return self._within(self._root_real, os.path.realpath(fpath))
+            resolved = os.path.realpath(fpath)
+            if not self._within(self._root_real, resolved):
+                return False
+            # Checked again on the resolved path: a symlink to `.git` is
+            # inside the checkout, so containment alone lets it through.
+            return not self._is_repo_internal(
+                os.path.relpath(resolved, self._root_real)
+            )
         except (OSError, ValueError):
             return False
 

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -200,8 +200,9 @@ def refuse_if_shared(repo: git.Repo) -> None:
     Reads share one copy per project; writes each get their own. Committing
     in the shared one would author it in a tree other people are reading,
     and push it under whichever credentials that copy happens to hold. A
-    caller that ends up here asked for a shared read and then tried to
-    write, which is a bug in the caller rather than anything a user did.
+    caller that ends up here asked ``get_repo`` for a read-only repo and
+    then wrote to it, which is a bug in the caller rather than anything
+    a user did.
     """
     if is_shared_read_checkout(repo):
         raise HTTPException(
@@ -243,32 +244,36 @@ def get_repo(
     ttl: int | None = None,
     fresh=False,
     ref: str | None = None,
-    shared_read: bool = False,
+    read_only: bool = False,
 ) -> git.Repo:
     """Ensure that the repo exists and is ready for operating upon for the user.
 
     Handles concurrency in case multiple API calls request the repo
     simultaneously. If TTL is None, the latest version is always fetched.
 
-    ``shared_read`` asks for the checkout everybody reads from rather than
-    this user's own. What a commit contains is the same whoever is looking,
-    so a project needs one copy for reading, not one per viewer -- and one
-    that stays warm for the next person instead of being cloned again.
+    ``read_only`` promises the caller will only read, which lets every
+    reader of a project share one checkout instead of cloning their own.
+    What a commit contains is the same whoever is looking, so a project
+    needs one copy for reading, not one per viewer -- and one that stays
+    warm for the next person rather than being cloned again.
 
-    It is opt-in, and deliberately so: the shared checkout must never be
-    written to, since a commit made there would be authored in a tree other
-    people are reading. A caller that doesn't ask for it gets its own
-    checkout exactly as before, so the cost of missing one is a slow read
-    rather than a wrong write.
+    It is opt-in, and deliberately so: a caller that doesn't ask for it
+    gets its own checkout exactly as before, so the cost of missing one is
+    a slow read rather than a wrong write. Breaking the promise is caught
+    rather than trusted -- see ``refuse_if_shared``.
     """
     owner_name = project.owner_github_name
     project_name = project.name
     shared_token: str | None = None
-    if shared_read:
-        shared_read, shared_token = _shared_read_token(project)
+    # Read-only is what the caller asks for; sharing is how it's answered,
+    # and a private repo the App isn't installed on can't be answered that
+    # way at all. Those fall back to a per-user checkout, still read-only.
+    shared = False
+    if read_only:
+        shared, shared_token = _shared_read_token(project)
     # Add the file to the repo(s) -- we may need to clone it.
     # Ref-based reads should not mutate this working tree checkout.
-    if shared_read:
+    if shared:
         base_dir = os.path.join(
             settings.CLONE_ROOT, SHARED_READER_DIR, owner_name, project_name
         )
@@ -299,7 +304,7 @@ def get_repo(
             os.remove(updated_fpath)
     # Clone the repo if it doesn't exist -- it will be in a "repo" dir
     access_token: str | None = None
-    if shared_read:
+    if shared:
         # The shared checkout belongs to the project, not to whoever asked
         # for it, so it carries the project's credentials and never a
         # user's. Nothing here is authorized by this: the caller has
@@ -623,7 +628,7 @@ def get_repo(
     # have stored the literal string "None" as the committer, so we
     # re-run on every refresh to repair that -- but not on every cached
     # read, which would be pure overhead.
-    if user is not None and did_refresh and not shared_read:
+    if user is not None and did_refresh and not shared:
         _configure_committer(repo, user, session=session)
     if did_refresh:
         record_project_update(project, repo, session)

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -154,7 +154,7 @@ REMOTE_HEAD_TTL = 300
 
 
 def get_remote_head_sha(
-    repo: git.Repo, remote_url: str, branch: str
+    repo: git.Repo, remote_url: str, branch: str, use_cache: bool = True
 ) -> str | None:
     """The SHA ``origin`` has for ``branch``, or None if it can't be read.
 
@@ -164,9 +164,10 @@ def get_remote_head_sha(
     back equal to what we already have, the fetch can be skipped entirely.
     """
     key = cache.make_key("remote-head", remote_url, branch)
-    cached = cache.get_json(key)
-    if isinstance(cached, str):
-        return cached
+    if use_cache:
+        cached = cache.get_json(key)
+        if isinstance(cached, str):
+            return cached
     try:
         with _timed("ls-remote", branch=branch):
             out = repo.git.ls_remote(
@@ -593,8 +594,18 @@ def get_repo(
                         local_head: str | None = repo.head.commit.hexsha
                     except (ValueError, GitCommandError):
                         local_head = None
+                    # A caller asking for ttl 0/None wants the truth, not
+                    # a cached answer. That is the path a push takes, and a
+                    # head cached from before it would say "already current"
+                    # and mark a stale clone fresh -- so the warm a push
+                    # queues would rebuild everything at the old commit.
                     remote_head = (
-                        get_remote_head_sha(repo, git_plain_url, branch_name)
+                        get_remote_head_sha(
+                            repo,
+                            git_plain_url,
+                            branch_name,
+                            use_cache=bool(ttl),
+                        )
                         if local_head
                         else None
                     )

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -203,11 +203,20 @@ def _clone_dir_segment(name: str) -> str:
     return segment
 
 
+def shared_reader_root() -> str:
+    """The directory the shared read-only checkouts live under."""
+    return os.path.join(settings.CLONE_ROOT, SHARED_READER_DIR)
+
+
 def is_shared_read_checkout(repo: git.Repo) -> bool:
-    """Whether this repo is the checkout everybody reads from."""
-    return (os.sep + SHARED_READER_DIR + os.sep) in os.path.abspath(
-        str(repo.working_dir)
-    )
+    """Whether this repo is the checkout everybody reads from.
+
+    Against the actual shared root, not any ``_shared`` segment: CLONE_ROOT
+    could itself contain one, and a writable clone misread as shared makes
+    ``_configure_committer`` 500 on a perfectly good repo.
+    """
+    root = os.path.abspath(shared_reader_root())
+    return os.path.abspath(str(repo.working_dir)).startswith(root + os.sep)
 
 
 def refuse_if_shared(repo: git.Repo) -> None:
@@ -272,7 +281,11 @@ def _shared_read_token(project: Project) -> tuple[bool, str | None]:
         else (project.owner_github_name, project.name)
     )
     try:
-        return True, github.get_app_installation_token(gh_owner, gh_repo)
+        # Read-only: this token goes into the checkout everyone reads, so it
+        # should not be able to write even if something tries.
+        return True, github.get_app_installation_token(
+            gh_owner, gh_repo, read_only=True
+        )
     except (github.GitHubAppNotConfigured, HTTPException) as e:
         logger.info(
             f"No shared checkout for private {gh_owner}/{gh_repo}: {e}"
@@ -310,9 +323,7 @@ def get_repo(
     # Add the file to the repo(s) -- we may need to clone it.
     # Ref-based reads should not mutate this working tree checkout.
     if shared:
-        base_dir = os.path.join(
-            settings.CLONE_ROOT, SHARED_READER_DIR, owner_name, project_name
-        )
+        base_dir = os.path.join(shared_reader_root(), owner_name, project_name)
     elif user is not None:
         # github_username is None for GitHub-less users; fall back to the
         # (always-present, unique) account name for a stable temp path.
@@ -383,8 +394,10 @@ def get_repo(
                 )
                 try:
                     with _timed("get-app-installation-token", user=user.email):
+                        # A read-only caller gets a token that can't push,
+                        # whether or not it ended up on a shared checkout.
                         access_token = github.get_app_installation_token(
-                            gh_owner, gh_repo
+                            gh_owner, gh_repo, read_only=read_only
                         )
                 except (github.GitHubAppNotConfigured, HTTPException) as e:
                     # A public repo can still be read/cloned unauthenticated,

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -831,12 +831,19 @@ def get_dvc_pipeline(
     return get_dvc_pipeline_from_repo(repo)
 
 
-def get_dvc_pipeline_from_repo(repo: git.Repo) -> dict:
-    if os.path.isfile(os.path.join(repo.working_dir, "dvc.yaml")):
-        with open(os.path.join(repo.working_dir, "dvc.yaml")) as f:
-            return ryaml.load(f)
-    else:
+def get_dvc_pipeline_from_repo(
+    repo: git.Repo, read_only: bool = False
+) -> dict:
+    """Load dvc.yaml from the repo's working tree.
+
+    ``read_only`` swaps ruamel's round-trip parser for the C loader; on a
+    large dvc.yaml that is the difference between ~300ms and a few.
+    """
+    fpath = os.path.join(repo.working_dir, "dvc.yaml")
+    if not os.path.isfile(fpath):
         return {}
+    with open(fpath) as f:
+        return (load_yaml_fast(f.read()) if read_only else ryaml.load(f)) or {}
 
 
 def get_overleaf_repo(

--- a/hub/backend/app/git.py
+++ b/hub/backend/app/git.py
@@ -1,6 +1,7 @@
 """Functionality for working with Git."""
 
 import atexit
+import hashlib
 import json
 import os
 import posixpath
@@ -181,10 +182,29 @@ def get_remote_head_sha(
     return sha
 
 
-# Where the one checkout everybody reads from lives, under CLONE_ROOT. Not a
-# possible account name (see INVALID_ACCOUNT_NAMES), and the leading
-# underscore keeps it from colliding with one anyway.
+# Where the one checkout everybody reads from lives, under CLONE_ROOT. A
+# GitHub name can hold only letters, digits and hyphens, so no owner can
+# ever be spelled this way; ``_clone_dir_segment`` keeps the per-user
+# directories out of it too, since an account name is not so constrained.
 SHARED_READER_DIR = "_shared"
+
+
+def _clone_dir_segment(name: str) -> str:
+    """Make ``name`` safe to use as one directory under ``CLONE_ROOT``.
+
+    The per-user checkout directory is named after the requester, and an
+    account name is whatever they typed at signup -- it is unique and
+    non-empty, and nothing else. A name of ``..`` would put their checkouts
+    outside ``CLONE_ROOT`` entirely, and one of ``_shared`` would put their
+    *writable* checkouts on top of the tree every reader of that project
+    reads from. Both are one signup away, so neither is left to convention.
+    """
+    segment = name.replace(os.sep, "_").replace("/", "_")
+    if segment in ("", ".", "..", SHARED_READER_DIR):
+        # Distinct from the name it stands in for, and still stable for
+        # this account, so the checkout is found again next time.
+        segment = "acct_" + hashlib.sha256(name.encode()).hexdigest()[:16]
+    return segment
 
 
 def is_shared_read_checkout(repo: git.Repo) -> bool:
@@ -208,6 +228,51 @@ def refuse_if_shared(repo: git.Repo) -> None:
         raise HTTPException(
             500, "Refusing to write to the shared read-only checkout"
         )
+
+
+# Hooks that make the shared checkout refuse to be written to, from inside
+# Git itself. `pre-commit` is the one that matters -- a commit there would be
+# authored in a tree other people are reading -- and `pre-push` goes with it
+# because the shared checkout is the one carrying the project's own
+# credentials, so a push from it is the version of that mistake that leaves
+# the machine.
+_SHARED_HOOKS = ("pre-commit", "pre-push")
+_SHARED_HOOK_SCRIPT = (
+    "#!/bin/sh\n"
+    "# Installed by Calkit. This is the shared read-only checkout every\n"
+    "# reader of this project sees; writes get their own copy.\n"
+    'echo "calkit: refusing to write to the shared read-only checkout" >&2\n'
+    "exit 1\n"
+)
+
+
+def _install_read_only_hooks(repo_dir: str) -> None:
+    """Make ``repo_dir`` refuse commits and pushes at the Git level.
+
+    ``refuse_if_shared`` catches a caller that asked ``get_repo`` for a
+    read-only repo and then wrote to it, but only where we thought to call
+    it, and only for writes that go through our own helpers. The hooks sit
+    under all of it: anything reaching ``git commit`` in this tree fails,
+    whether it came through GitPython, a subprocess, or DVC.
+
+    Best effort by design -- a checkout we cannot write a hook into is
+    still readable, and refusing to serve it would turn a hardening measure
+    into an outage.
+    """
+    hooks_dir = os.path.join(repo_dir, ".git", "hooks")
+    try:
+        os.makedirs(hooks_dir, exist_ok=True)
+        for name in _SHARED_HOOKS:
+            fpath = os.path.join(hooks_dir, name)
+            # Written once per checkout, so the common case is two stats.
+            # An existing hook that isn't executable is one Git ignores.
+            if os.path.isfile(fpath) and os.access(fpath, os.X_OK):
+                continue
+            with open(fpath, "w") as f:
+                f.write(_SHARED_HOOK_SCRIPT)
+            os.chmod(fpath, 0o755)
+    except OSError as e:
+        logger.warning(f"Could not install read-only hooks in {repo_dir}: {e}")
 
 
 def _shared_read_token(project: Project) -> tuple[bool, str | None]:
@@ -280,7 +345,9 @@ def get_repo(
     elif user is not None:
         # github_username is None for GitHub-less users; fall back to the
         # (always-present, unique) account name for a stable temp path.
-        user_dir = user.github_username or user.account.name
+        user_dir = _clone_dir_segment(
+            user.github_username or user.account.name
+        )
         base_dir = os.path.join(
             settings.CLONE_ROOT, user_dir, owner_name, project_name
         )
@@ -474,6 +541,11 @@ def get_repo(
             "This project is still being prepared. Try again in a moment.",
             headers={"Retry-After": "5"},
         )
+    if shared:
+        # Here rather than next to the clone so it also covers the checkouts
+        # that already exist, and the TTL fast path that returns below
+        # without ever going near the clone code.
+        _install_read_only_hooks(repo_dir)
     last_updated = os.path.getmtime(updated_fpath)
     did_refresh = newly_cloned
     if not newly_cloned:
@@ -761,16 +833,24 @@ def get_ck_info(
     session: Session,
     ttl=None,
     ref: str | None = None,
+    read_only: bool = False,
 ) -> dict:
-    """Load the calkit.yaml file contents into a dictionary."""
+    """Load the calkit.yaml file contents into a dictionary.
+
+    ``read_only`` promises the caller only inspects the result and never
+    writes it back, which lets both the checkout and the parser take their
+    cheap forms: the shared read-only clone (see ``get_repo``) and the C
+    loader rather than ruamel's round-trip one.
+    """
     repo = get_repo(
         project=project,
         user=user,
         session=session,
         ttl=ttl,
         ref=ref,
+        read_only=read_only,
     )
-    return get_ck_info_from_repo(repo=repo)
+    return get_ck_info_from_repo(repo=repo, read_only=read_only)
 
 
 def get_dvc_pipeline(
@@ -1610,46 +1690,95 @@ class RepoTree(ABC):
 
 
 class WorkingTree(RepoTree):
-    """RepoTree backed by a live filesystem checkout."""
+    """RepoTree backed by a live filesystem checkout.
+
+    Unlike ``GitTree``, which can only name objects that are actually in a
+    commit, this reaches the filesystem -- so "the path is inside the repo"
+    is a claim to check rather than one to assume. Paths arrive here from
+    ``calkit.yaml`` and from request URLs, and every project's checkout sits
+    at a predictable path beside every other project's under ``CLONE_ROOT``
+    (``_shared/<owner>/<project>/repo`` most predictably of all). A path
+    that walks out of this repo walks straight into someone else's, whether
+    or not the reader can see that project.
+    """
 
     def __init__(self, root: str) -> None:
         self._root = root
+        self._root_norm = os.path.normpath(root)
+        # Resolved once here rather than per call, and kept apart from the
+        # normalized form: CLONE_ROOT itself may be a symlink, so a resolved
+        # path has to be compared against a resolved root or every read in
+        # the checkout looks like it escapes.
+        try:
+            self._root_real = os.path.realpath(root)
+        except (OSError, ValueError):
+            self._root_real = self._root_norm
 
-    def _abs(self, path: str | None) -> str:
-        return self._root if not path else os.path.join(self._root, path)
+    @staticmethod
+    def _within(root: str, candidate: str) -> bool:
+        return candidate == root or candidate.startswith(root + os.sep)
+
+    def _abs(self, path: str | None) -> str | None:
+        """Absolute path for ``path``, or ``None`` if it leaves the checkout.
+
+        Lexical, so it costs no syscalls in the directory listings that call
+        it once per entry. Symlinks pointing out of the tree are a separate
+        question, answered by ``is_safe_symlink`` and by ``read_bytes``.
+        """
+        if not path:
+            return self._root
+        full = os.path.join(self._root, path)
+        if not self._within(self._root_norm, os.path.normpath(full)):
+            logger.warning(f"Refusing path outside {self._root}: {path!r}")
+            return None
+        return full
 
     def exists(self, path: str) -> bool:
-        return os.path.exists(self._abs(path))
+        fpath = self._abs(path)
+        return fpath is not None and os.path.exists(fpath)
 
     def is_file(self, path: str) -> bool:
-        return os.path.isfile(self._abs(path))
+        fpath = self._abs(path)
+        return fpath is not None and os.path.isfile(fpath)
 
     def is_dir(self, path: str | None) -> bool:
-        return os.path.isdir(self._abs(path))
+        fpath = self._abs(path)
+        return fpath is not None and os.path.isdir(fpath)
 
     def is_symlink(self, path: str) -> bool:
-        return os.path.islink(self._abs(path))
+        fpath = self._abs(path)
+        return fpath is not None and os.path.islink(fpath)
 
     def is_safe_symlink(self, path: str) -> bool:
+        fpath = self._abs(path)
+        if fpath is None:
+            return False
         try:
-            resolved = os.path.realpath(self._abs(path))
-            root_real = os.path.realpath(self._root)
-            return (
-                resolved.startswith(root_real + os.sep)
-                or resolved == root_real
-            )
+            return self._within(self._root_real, os.path.realpath(fpath))
         except (OSError, ValueError):
             return False
 
     def read_bytes(self, path: str) -> bytes:
-        with open(self._abs(path), "rb") as f:
+        fpath = self._abs(path)
+        # Content is what actually leaves the machine, so this one pays for
+        # a resolved check too: a symlink out of the tree reads whatever it
+        # points at, and `..` is only the obvious way to spell that.
+        if fpath is None or not self.is_safe_symlink(path):
+            raise HTTPException(404)
+        with open(fpath, "rb") as f:
             return f.read()
 
     def size(self, path: str) -> int:
-        return os.path.getsize(self._abs(path))
+        fpath = self._abs(path)
+        if fpath is None:
+            raise HTTPException(404)
+        return os.path.getsize(fpath)
 
     def listdir(self, path: str | None) -> list[str]:
-        return os.listdir(self._abs(path))
+        fpath = self._abs(path)
+        if fpath is None:
+            raise HTTPException(404)
+        return os.listdir(fpath)
 
 
 _ODB_LOCK_ATTR = "_calkit_odb_lock"

--- a/hub/backend/app/github.py
+++ b/hub/backend/app/github.py
@@ -51,22 +51,30 @@ def create_app_token() -> str:
 # before expiry means a GitHub-less user's request doesn't mint a fresh token
 # (two GitHub API calls) on every repo operation. This is a per-worker
 # in-process cache, so each worker mints at most once per repo per ~hour.
-_installation_token_cache: dict[tuple[str, str], tuple[str, float]] = {}
+_installation_token_cache: dict[tuple[str, str, bool], tuple[str, float]] = {}
 _installation_token_cache_lock = threading.Lock()
 # Refresh this long before GitHub's stated expiry so a cached token can't lapse
 # mid-request.
 _INSTALLATION_TOKEN_SAFETY_SECONDS = 300
 
 
-def get_app_installation_token(owner_name: str, repo_name: str) -> str:
+def get_app_installation_token(
+    owner_name: str, repo_name: str, read_only: bool = False
+) -> str:
     """Return a GitHub App installation access token scoped to one repo.
 
     Used to perform git operations on behalf of users who have native Calkit
     access to a project but no personal GitHub token (e.g. email/Google
     signups). Tokens are cached in-process and reused until shortly before they
     expire. The caller must have authorized the user's access first.
+
+    ``read_only`` narrows the token to ``contents: read``, so it can clone
+    and fetch but not push. The shared read-only checkout takes one of
+    these: it is read by everyone with access to the project, and a token
+    that cannot write is a better guarantee than one that merely shouldn't.
+    Cached separately, so a reader never picks up a writable token.
     """
-    cache_key = (owner_name.lower(), repo_name.lower())
+    cache_key = (owner_name.lower(), repo_name.lower(), read_only)
     now = time.time()
     with _installation_token_cache_lock:
         cached = _installation_token_cache.get(cache_key)
@@ -75,7 +83,9 @@ def get_app_installation_token(owner_name: str, repo_name: str) -> str:
     # Miss or expired: mint a fresh token. Done outside the lock so requests
     # for different repos don't serialize; a rare concurrent double-mint just
     # yields two valid tokens.
-    token, expires_at = _mint_app_installation_token(owner_name, repo_name)
+    token, expires_at = _mint_app_installation_token(
+        owner_name, repo_name, read_only=read_only
+    )
     # ~50 min fallback if GitHub omits expires_at for some reason.
     expiry = now + 3000.0
     if expires_at:
@@ -90,7 +100,7 @@ def get_app_installation_token(owner_name: str, repo_name: str) -> str:
 
 
 def _mint_app_installation_token(
-    owner_name: str, repo_name: str
+    owner_name: str, repo_name: str, read_only: bool = False
 ) -> tuple[str, str | None]:
     """Mint a fresh installation token, returning (token, expires_at)."""
     app_jwt = create_app_token()
@@ -119,7 +129,13 @@ def _mint_app_installation_token(
         f"https://api.github.com/app/installations/{installation_id}"
         "/access_tokens",
         headers=headers,
-        json={"repositories": [repo_name]},
+        json=(
+            {"repositories": [repo_name], "permissions": {"contents": "read"}}
+            if read_only
+            # Otherwise the installation's own permissions, which is what a
+            # push needs. Narrowing is allowed; widening is not.
+            else {"repositories": [repo_name]}
+        ),
         timeout=15,
     )
     if resp.status_code not in (200, 201):

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -1276,21 +1276,24 @@ def get_ck_info_for_ref(
     project: Project,
     repo: git.Repo,
     ref: str | None = None,
-    read_only: bool = False,
 ) -> dict:
     """Return Calkit metadata for the requested ref, if provided.
 
     Always returns a dict; an empty one when calkit.yaml doesn't exist at
     the ref or doesn't hold a mapping. Declared artifact paths come back
-    normalized (see ``normalize_ck_info_paths``), so callers must not write
-    the result back to calkit.yaml.
+    normalized (see ``normalize_ck_info_paths``, which rewrites them in
+    place), so what comes back here must never be written to calkit.yaml.
 
-    Pass ``read_only=True`` only when the caller won't write the result back;
-    see ``get_ck_info_from_repo``.
+    Which is why there is no choice of parser: ruamel's round-trip mode
+    exists to preserve the comments and quoting a faithful rewrite needs,
+    and nothing may rewrite this. On a large calkit.yaml that is a quarter
+    of a second per request, paid by most of the project view. Callers that
+    do write calkit.yaml back read it through ``get_ck_info_from_repo``
+    instead.
     """
     if ref is None:
         return normalize_ck_info_paths(
-            get_ck_info_from_repo(repo=repo, read_only=read_only)
+            get_ck_info_from_repo(repo=repo, read_only=True)
         )
     try:
         ck_item = get_contents_from_repo(

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -1333,7 +1333,7 @@ def get_dvc_pipeline_for_ref(
     not check it out), so it must not be used for ref-scoped reads.
     """
     if ref is None:
-        return get_dvc_pipeline_from_repo(repo)
+        return get_dvc_pipeline_from_repo(repo, read_only=True)
     tree = get_repo_tree_for_ref(repo, ref)
     if not tree.is_file("dvc.yaml"):
         return {}

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -342,12 +342,9 @@ def read_project_file(
     than ``max_bytes``, checked before reading and again after, since a
     DVC output's recorded size is what the pusher said it was.
 
-    Raises 400 for a path that isn't inside the project. Callers reach here
-    with a path straight out of a request URL (the dataset viewers take one
-    as ``{path:path}``), and ``WorkingTree`` reads the live checkout, which
-    sits next to every other project's under ``CLONE_ROOT``. The tree
-    refuses such a path too; this says so in the answer rather than
-    reporting a file that "isn't in this project".
+    Raises 400 for a path outside the project: callers reach here with one
+    straight out of a request URL, and ``WorkingTree`` reads the live
+    checkout. The tree refuses it too; this just answers more clearly.
     """
     if os.path.isabs(path) or ".." in path.split("/"):
         raise HTTPException(400, "Path traversal is not allowed")
@@ -1290,16 +1287,12 @@ def get_ck_info_for_ref(
 
     Always returns a dict; an empty one when calkit.yaml doesn't exist at
     the ref or doesn't hold a mapping. Declared artifact paths come back
-    normalized (see ``normalize_ck_info_paths``, which rewrites them in
-    place), so what comes back here must never be written to calkit.yaml.
+    normalized in place (see ``normalize_ck_info_paths``), so what comes
+    back must never be written to calkit.yaml.
 
-    Which is why this always parses read-only, and offers no choice about
-    it: ruamel's round-trip mode exists to preserve the comments and
-    quoting a faithful rewrite needs, and nothing may rewrite what comes
-    back from here. Round-tripping a large calkit.yaml costs a quarter of a
-    second per request, paid by most of the project view. Callers that do
-    write calkit.yaml back read it through ``get_ck_info_from_repo``
-    instead.
+    Hence it always parses read-only: round-tripping a large calkit.yaml
+    costs a quarter of a second, and only a faithful rewrite needs that.
+    Callers that do write it back use ``get_ck_info_from_repo``.
     """
     if ref is None:
         return normalize_ck_info_paths(

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -1284,11 +1284,12 @@ def get_ck_info_for_ref(
     normalized (see ``normalize_ck_info_paths``, which rewrites them in
     place), so what comes back here must never be written to calkit.yaml.
 
-    Which is why there is no choice of parser: ruamel's round-trip mode
-    exists to preserve the comments and quoting a faithful rewrite needs,
-    and nothing may rewrite this. On a large calkit.yaml that is a quarter
-    of a second per request, paid by most of the project view. Callers that
-    do write calkit.yaml back read it through ``get_ck_info_from_repo``
+    Which is why this always parses read-only, and offers no choice about
+    it: ruamel's round-trip mode exists to preserve the comments and
+    quoting a faithful rewrite needs, and nothing may rewrite what comes
+    back from here. Round-tripping a large calkit.yaml costs a quarter of a
+    second per request, paid by most of the project view. Callers that do
+    write calkit.yaml back read it through ``get_ck_info_from_repo``
     instead.
     """
     if ref is None:

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -341,7 +341,16 @@ def read_project_file(
     project) or its object was never pushed, and 413 when it's larger
     than ``max_bytes``, checked before reading and again after, since a
     DVC output's recorded size is what the pusher said it was.
+
+    Raises 400 for a path that isn't inside the project. Callers reach here
+    with a path straight out of a request URL (the dataset viewers take one
+    as ``{path:path}``), and ``WorkingTree`` reads the live checkout, which
+    sits next to every other project's under ``CLONE_ROOT``. The tree
+    refuses such a path too; this says so in the answer rather than
+    reporting a file that "isn't in this project".
     """
+    if os.path.isabs(path) or ".." in path.split("/"):
+        raise HTTPException(400, "Path traversal is not allowed")
     if not dvc_only and tree.is_file(path):
         data = bytes(tree.read_bytes(path))
         if len(data) > max_bytes:

--- a/hub/backend/app/projects.py
+++ b/hub/backend/app/projects.py
@@ -894,7 +894,10 @@ def get_contents_from_tree(
         p for p, obj in dvc_lock_outs.items() if obj["type"] == "dir"
     ]
     ignore_paths = [".git", ".dvc/cache", ".dvc/tmp", ".dvc/config.local"]
-    if path is not None and path in ignore_paths:
+    # Prefixes, not exact names: ".git" alone left ".git/config" readable.
+    if path is not None and any(
+        path == p or path.startswith(p + "/") for p in ignore_paths
+    ):
         raise HTTPException(404)
     # Let's restructure as a dictionary keyed by path
     categories_with_path = [

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -526,7 +526,7 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             user=None,
             session=None,
             ttl=600,
-            shared_read=True,
+            read_only=True,
         )
         assert app.git.SHARED_READER_DIR in str(repo.working_dir)
         assert len(clones) == 1
@@ -535,7 +535,7 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             user=None,
             session=None,
             ttl=600,
-            shared_read=True,
+            read_only=True,
         )
         assert len(clones) == 1
         # And it is recognisable as the shared one, so a write that lands
@@ -566,7 +566,7 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             user=None,
             session=None,
             ttl=600,
-            shared_read=True,
+            read_only=True,
         )
         assert app.git.SHARED_READER_DIR not in str(private.working_dir)
     finally:

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -519,8 +519,8 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
         project.name,
     )
     try:
-        # A public project reads from one copy, wherever the request came
-        # from, so a second reader finds it already there
+        # A public project reads from one copy, so a second reader finds
+        # it already there
         repo = app.git.get_repo(
             project=project,
             user=None,
@@ -538,14 +538,13 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             read_only=True,
         )
         assert len(clones) == 1
-        # And it is recognisable as the shared one, so a write that lands
-        # there is refused rather than authored in a tree others are reading
+        # A write that lands there is refused, not authored in a tree
+        # others are reading
         assert app.git.is_shared_read_checkout(repo)
         with pytest.raises(HTTPException) as excinfo:
             app.git.refuse_if_shared(repo)
         assert excinfo.value.status_code == 500
-        # Git itself refuses too, so a write that never goes through our
-        # helpers is stopped as well
+        # Git refuses too, so a write bypassing our helpers is stopped
         hooks_dir = os.path.join(str(repo.working_dir), ".git", "hooks")
         for hook in app.git._SHARED_HOOKS:
             assert os.access(os.path.join(hooks_dir, hook), os.X_OK)
@@ -561,8 +560,7 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
         assert app.git.SHARED_READER_DIR not in str(own.working_dir)
         assert not app.git.is_shared_read_checkout(own)
         assert len(clones) == 2
-        # A private project with no App installation has no shared copy to
-        # read from, so it quietly keeps using its own
+        # A private project with no App installation keeps its own copy
         project.is_public = False
         monkeypatch.setattr(
             app.github,
@@ -579,16 +577,15 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             read_only=True,
         )
         assert app.git.SHARED_READER_DIR not in str(private.working_dir)
-        # An account name is whatever someone typed at signup, so the two
-        # that would land their writable checkout somewhere it must never go
-        # are renamed rather than trusted
+        # The account names that would land a writable checkout somewhere
+        # it must never go are renamed rather than trusted
         assert app.git._clone_dir_segment("octocat") == "octocat"
         for hostile in ("..", ".", "", app.git.SHARED_READER_DIR):
             segment = app.git._clone_dir_segment(hostile)
             assert segment.startswith("acct_")
             assert segment != app.git.SHARED_READER_DIR
         assert app.git._clone_dir_segment("a/b") == "a_b"
-        # Stable, so the same account finds its checkout again next time
+        # Stable across calls
         assert app.git._clone_dir_segment("..") == app.git._clone_dir_segment(
             ".."
         )
@@ -598,7 +595,7 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
 
 
 def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
-    # Two checkouts side by side, the way CLONE_ROOT holds every project's
+    # Two checkouts side by side, the way CLONE_ROOT holds them
     victim = tmp_path / "_shared" / "victim-owner" / "victim-proj" / "repo"
     ours = tmp_path / "_shared" / "us" / "our-proj" / "repo"
     victim.mkdir(parents=True)
@@ -611,7 +608,7 @@ def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
     assert tree.read_bytes("ours.csv") == b"ours\n"
     assert tree.size("ours.csv") == 5
     assert "ours.csv" in tree.listdir(None)
-    # Walking out of the checkout finds nothing, however it is spelled
+    # Walking out finds nothing, however it is spelled
     escapes = [
         "../../../victim-owner/victim-proj/repo/private.csv",
         "a/../../../../victim-owner/victim-proj/repo/private.csv",
@@ -626,13 +623,13 @@ def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
         assert excinfo.value.status_code == 404
     with pytest.raises(HTTPException):
         tree.listdir("../../../victim-owner/victim-proj/repo")
-    # A symlink is the other way to spell it, so content reads resolve
+    # A symlink is the other way out, so content reads resolve
     (ours / "link.csv").symlink_to(victim / "private.csv")
     assert tree.is_file("link.csv")
     assert not tree.is_safe_symlink("link.csv")
     with pytest.raises(HTTPException):
         tree.read_bytes("link.csv")
-    # And a symlink that stays inside the checkout still reads
+    # One that stays inside still reads
     (ours / "inside.csv").symlink_to(ours / "ours.csv")
     assert tree.is_safe_symlink("inside.csv")
     assert tree.read_bytes("inside.csv") == b"ours\n"

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -479,3 +479,96 @@ def test_get_repo_applies_the_configured_clone_filter(monkeypatch):
         assert not any(a.startswith("--filter") for a in commands[1])
     finally:
         _shutil.rmtree(base_dir, ignore_errors=True)
+
+
+def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
+    import shutil as _shutil
+
+    from app.config import settings
+
+    project = _StubProject(f"ck-shared-{random.randint(0, 10**9)}")
+    monkeypatch.setattr(app.git, "record_project_update", lambda *a, **k: None)
+    real_check_call = app.git.subprocess.check_call
+    clones: list[str] = []
+
+    def fake_check_call(cmd, *args, **kwargs):
+        if cmd[:2] == ["git", "clone"]:
+            target = cmd[-1]
+            clones.append(target)
+            os.makedirs(target, exist_ok=True)
+            r = git.Repo.init(target)
+            r.git.config(["user.name", "CI Test"])
+            r.git.config(["user.email", "ci-test@example.com"])
+            (Path(target) / "notes.txt").write_text("one")
+            r.git.add(["notes.txt"])
+            r.git.commit(["-m", "Init"])
+            return 0
+        return real_check_call(cmd, *args, **kwargs)
+
+    monkeypatch.setattr(app.git.subprocess, "check_call", fake_check_call)
+    shared_base = os.path.join(
+        settings.CLONE_ROOT,
+        app.git.SHARED_READER_DIR,
+        project.owner_github_name,
+        project.name,
+    )
+    anon_base = os.path.join(
+        settings.CLONE_ROOT,
+        "anonymous",
+        project.owner_github_name,
+        project.name,
+    )
+    try:
+        # A public project reads from one copy, wherever the request came
+        # from, so a second reader finds it already there
+        repo = app.git.get_repo(
+            project=project,
+            user=None,
+            session=None,
+            ttl=600,
+            shared_read=True,
+        )
+        assert app.git.SHARED_READER_DIR in str(repo.working_dir)
+        assert len(clones) == 1
+        app.git.get_repo(
+            project=project,
+            user=None,
+            session=None,
+            ttl=600,
+            shared_read=True,
+        )
+        assert len(clones) == 1
+        # And it is recognisable as the shared one, so a write that lands
+        # there is refused rather than authored in a tree others are reading
+        assert app.git.is_shared_read_checkout(repo)
+        with pytest.raises(HTTPException) as excinfo:
+            app.git.refuse_if_shared(repo)
+        assert excinfo.value.status_code == 500
+        # Not asking for it gets the caller its own copy, exactly as before
+        own = app.git.get_repo(
+            project=project, user=None, session=None, ttl=600
+        )
+        assert app.git.SHARED_READER_DIR not in str(own.working_dir)
+        assert not app.git.is_shared_read_checkout(own)
+        assert len(clones) == 2
+        # A private project with no App installation has no shared copy to
+        # read from, so it quietly keeps using its own
+        project.is_public = False
+        monkeypatch.setattr(
+            app.github,
+            "get_app_installation_token",
+            lambda *a, **k: (_ for _ in ()).throw(
+                app.github.GitHubAppNotConfigured("no app")
+            ),
+        )
+        private = app.git.get_repo(
+            project=project,
+            user=None,
+            session=None,
+            ttl=600,
+            shared_read=True,
+        )
+        assert app.git.SHARED_READER_DIR not in str(private.working_dir)
+    finally:
+        _shutil.rmtree(shared_base, ignore_errors=True)
+        _shutil.rmtree(anon_base, ignore_errors=True)

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -623,6 +623,19 @@ def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
         assert excinfo.value.status_code == 404
     with pytest.raises(HTTPException):
         tree.listdir("../../../victim-owner/victim-proj/repo")
+    # Repo plumbing is not project content, however it is spelled, but a
+    # name that merely starts with ".git" is
+    (ours / ".gitignore").write_text("*.pyc\n")
+    for internal in (".git", ".git/config", "a/../.git/config"):
+        assert not tree.is_file(internal)
+        with pytest.raises(HTTPException):
+            tree.read_bytes(internal)
+    # A symlink is the spelling that survives normalization, so the
+    # resolved path is checked too
+    (ours / "link").symlink_to(".git")
+    with pytest.raises(HTTPException):
+        tree.read_bytes("link/config")
+    assert tree.read_bytes(".gitignore") == b"*.pyc\n"
     # A symlink is the other way out, so content reads resolve
     (ours / "link.csv").symlink_to(victim / "private.csv")
     assert tree.is_file("link.csv")

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -544,6 +544,16 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
         with pytest.raises(HTTPException) as excinfo:
             app.git.refuse_if_shared(repo)
         assert excinfo.value.status_code == 500
+        # Git itself refuses too, so a write that never goes through our
+        # helpers is stopped as well
+        hooks_dir = os.path.join(str(repo.working_dir), ".git", "hooks")
+        for hook in app.git._SHARED_HOOKS:
+            assert os.access(os.path.join(hooks_dir, hook), os.X_OK)
+        (Path(str(repo.working_dir)) / "notes.txt").write_text("two")
+        repo.git.add(["notes.txt"])
+        with pytest.raises(git.exc.GitCommandError):
+            repo.git.commit(["-m", "Should never land"])
+        repo.git.reset(["--hard"])
         # Not asking for it gets the caller its own copy, exactly as before
         own = app.git.get_repo(
             project=project, user=None, session=None, ttl=600
@@ -569,6 +579,60 @@ def test_shared_read_checkout_is_shared_and_never_written(monkeypatch):
             read_only=True,
         )
         assert app.git.SHARED_READER_DIR not in str(private.working_dir)
+        # An account name is whatever someone typed at signup, so the two
+        # that would land their writable checkout somewhere it must never go
+        # are renamed rather than trusted
+        assert app.git._clone_dir_segment("octocat") == "octocat"
+        for hostile in ("..", ".", "", app.git.SHARED_READER_DIR):
+            segment = app.git._clone_dir_segment(hostile)
+            assert segment.startswith("acct_")
+            assert segment != app.git.SHARED_READER_DIR
+        assert app.git._clone_dir_segment("a/b") == "a_b"
+        # Stable, so the same account finds its checkout again next time
+        assert app.git._clone_dir_segment("..") == app.git._clone_dir_segment(
+            ".."
+        )
     finally:
         _shutil.rmtree(shared_base, ignore_errors=True)
         _shutil.rmtree(anon_base, ignore_errors=True)
+
+
+def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
+    # Two checkouts side by side, the way CLONE_ROOT holds every project's
+    victim = tmp_path / "_shared" / "victim-owner" / "victim-proj" / "repo"
+    ours = tmp_path / "_shared" / "us" / "our-proj" / "repo"
+    victim.mkdir(parents=True)
+    ours.mkdir(parents=True)
+    (victim / "private.csv").write_text("secret,data\n")
+    (ours / "ours.csv").write_text("ours\n")
+    tree = app.git.WorkingTree(str(ours))
+    # Our own files read normally
+    assert tree.is_file("ours.csv")
+    assert tree.read_bytes("ours.csv") == b"ours\n"
+    assert tree.size("ours.csv") == 5
+    assert "ours.csv" in tree.listdir(None)
+    # Walking out of the checkout finds nothing, however it is spelled
+    escapes = [
+        "../../../victim-owner/victim-proj/repo/private.csv",
+        "a/../../../../victim-owner/victim-proj/repo/private.csv",
+        str(victim / "private.csv"),
+    ]
+    for path in escapes:
+        assert not tree.is_file(path)
+        assert not tree.exists(path)
+        assert not tree.is_safe_symlink(path)
+        with pytest.raises(HTTPException) as excinfo:
+            tree.read_bytes(path)
+        assert excinfo.value.status_code == 404
+    with pytest.raises(HTTPException):
+        tree.listdir("../../../victim-owner/victim-proj/repo")
+    # A symlink is the other way to spell it, so content reads resolve
+    (ours / "link.csv").symlink_to(victim / "private.csv")
+    assert tree.is_file("link.csv")
+    assert not tree.is_safe_symlink("link.csv")
+    with pytest.raises(HTTPException):
+        tree.read_bytes("link.csv")
+    # And a symlink that stays inside the checkout still reads
+    (ours / "inside.csv").symlink_to(ours / "ours.csv")
+    assert tree.is_safe_symlink("inside.csv")
+    assert tree.read_bytes("inside.csv") == b"ours\n"

--- a/hub/backend/app/tests/test_git.py
+++ b/hub/backend/app/tests/test_git.py
@@ -4,6 +4,7 @@ import concurrent.futures
 import json
 import os
 import random
+import subprocess
 from pathlib import Path
 
 import git
@@ -646,3 +647,51 @@ def test_working_tree_refuses_paths_outside_the_checkout(tmp_path):
     (ours / "inside.csv").symlink_to(ours / "ours.csv")
     assert tree.is_safe_symlink("inside.csv")
     assert tree.read_bytes("inside.csv") == b"ours\n"
+
+
+def test_remote_head_cache_is_bypassed_when_the_caller_wants_the_truth(
+    tmp_path,
+):
+    origin = tmp_path / "origin.git"
+    seed = tmp_path / "seed"
+    subprocess.check_call(
+        ["git", "init", "--bare", "-q", "-b", "main", str(origin)]
+    )
+    subprocess.check_call(["git", "init", "-q", "-b", "main", str(seed)])
+    for k, v in (("user.email", "ci@example.com"), ("user.name", "CI")):
+        subprocess.check_call(["git", "-C", str(seed), "config", k, v])
+    (seed / "f.txt").write_text("v1\n")
+    subprocess.check_call(["git", "-C", str(seed), "add", "f.txt"])
+    subprocess.check_call(["git", "-C", str(seed), "commit", "-qm", "v1"])
+    subprocess.check_call(
+        ["git", "-C", str(seed), "remote", "add", "origin", str(origin)]
+    )
+    subprocess.check_call(
+        ["git", "-C", str(seed), "push", "-q", "origin", "main"]
+    )
+    clone = tmp_path / "clone"
+    subprocess.check_call(["git", "clone", "-q", str(origin), str(clone)])
+    repo = git.Repo(str(clone))
+    old = repo.head.commit.hexsha
+    # A read before the push leaves the pre-push head in the cache
+    assert app.git.get_remote_head_sha(repo, str(origin), "main") == old
+    (seed / "f.txt").write_text("v2\n")
+    subprocess.check_call(["git", "-C", str(seed), "commit", "-qam", "v2"])
+    subprocess.check_call(
+        ["git", "-C", str(seed), "push", "-q", "origin", "main"]
+    )
+    new = (
+        subprocess.check_output(["git", "-C", str(seed), "rev-parse", "HEAD"])
+        .decode()
+        .strip()
+    )
+    assert new != old
+    # A cached read still answers with the old head, which is what let a
+    # push land without the warm it queued ever fetching it
+    assert app.git.get_remote_head_sha(repo, str(origin), "main") == old
+    # ttl=0/None callers ask the remote instead, and refresh the cache
+    assert (
+        app.git.get_remote_head_sha(repo, str(origin), "main", use_cache=False)
+        == new
+    )
+    assert app.git.get_remote_head_sha(repo, str(origin), "main") == new

--- a/hub/backend/app/thumbnails.py
+++ b/hub/backend/app/thumbnails.py
@@ -20,6 +20,7 @@ import base64
 import hashlib
 import io
 import threading
+from typing import Any
 
 from app import cache
 from app.core import logger
@@ -57,7 +58,9 @@ def _render_pdf_first_page(data: bytes, max_px: int) -> bytes | None:
         return _render_pdf_locked(pypdfium2, data, max_px)
 
 
-def _render_pdf_locked(pypdfium2, data: bytes, max_px: int) -> bytes | None:
+def _render_pdf_locked(
+    pypdfium2: Any, data: bytes, max_px: int
+) -> bytes | None:
     pdf = pypdfium2.PdfDocument(data)
     try:
         if len(pdf) == 0:
@@ -86,17 +89,17 @@ def _render_pdf_locked(pypdfium2, data: bytes, max_px: int) -> bytes | None:
 def _render_raster(data: bytes, max_px: int) -> bytes | None:
     from PIL import Image
 
-    with Image.open(io.BytesIO(data)) as image:
-        image.thumbnail((max_px, max_px))
+    with Image.open(io.BytesIO(data)) as opened:
+        opened.thumbnail((max_px, max_px))
         # A plot saved with transparency goes on white rather than on
         # whatever the page behind it happens to be.
-        if image.mode in ("RGBA", "LA", "P"):
-            background = Image.new("RGB", image.size, (255, 255, 255))
-            converted = image.convert("RGBA")
-            background.paste(converted, mask=converted.split()[-1])
-            image = background
+        image: Image.Image
+        if opened.mode in ("RGBA", "LA", "P"):
+            image = Image.new("RGB", opened.size, (255, 255, 255))
+            converted = opened.convert("RGBA")
+            image.paste(converted, mask=converted.split()[-1])
         else:
-            image = image.convert("RGB")
+            image = opened.convert("RGB")
         buf = io.BytesIO()
         image.save(buf, format="WEBP", quality=_WEBP_QUALITY, method=4)
         return buf.getvalue()

--- a/hub/backend/app/users.py
+++ b/hub/backend/app/users.py
@@ -15,7 +15,13 @@ from sqlmodel import Session, select
 import app.stripe
 from app import utcnow
 from app.config import settings
-from app.core import INVALID_ACCOUNT_NAMES, ORG_ONLY_ACCOUNT_NAMES
+from app.core import (
+    ACCOUNT_NAME_RULE,
+    INVALID_ACCOUNT_NAMES,
+    ORG_ONLY_ACCOUNT_NAMES,
+    account_name_is_valid,
+    sanitize_account_name,
+)
 from app.github import token_resp_text_to_dict
 from app.messaging import EMAIL_VERIFICATION_CODE_MINUTES
 from app.models import (
@@ -138,15 +144,29 @@ def check_email_allowed(email: str | None) -> None:
 
 def create_user(*, session: Session, user_create: UserCreate) -> User:
     check_email_allowed(user_create.email)
-    account_name = user_create.account_name or user_create.github_username
-    if not account_name:
-        account_name = user_create.email.split("@")[0]
+    # A name they typed is checked; one derived from a GitHub handle or an
+    # email address is cleaned up, since they never chose it and an address
+    # like "a.b+c@x.com" would otherwise be refused a signup.
+    # The name as typed is kept for display; the account itself is named by
+    # the normalized form.
+    display_name = user_create.account_name
+    if user_create.account_name:
+        account_name = user_create.account_name.lower()
+        if not account_name_is_valid(account_name):
+            raise HTTPException(422, ACCOUNT_NAME_RULE)
+    else:
+        account_name = sanitize_account_name(
+            user_create.github_username or user_create.email.split("@")[0]
+        )
+        if not account_name_is_valid(account_name):
+            # Nothing usable was left, so give them something that works;
+            # they can rename later.
+            account_name = f"user-{secrets.token_hex(4)}"
+        display_name = account_name
     # Only set a GitHub name when the user actually has a GitHub account;
     # GitHub-less (email/Google) signups leave it null.
     github_name = user_create.github_username
-    if account_name.lower() in (
-        INVALID_ACCOUNT_NAMES + ORG_ONLY_ACCOUNT_NAMES
-    ):
+    if account_name in (INVALID_ACCOUNT_NAMES + ORG_ONLY_ACCOUNT_NAMES):
         raise HTTPException(422, "Invalid account name")
     existing = session.exec(
         select(Account).where(Account.name == account_name.lower())
@@ -174,8 +194,8 @@ def create_user(*, session: Session, user_create: UserCreate) -> User:
         update={
             "hashed_password": get_password_hash(user_create.password),
             "account": Account(
-                name=account_name.lower(),
-                display_name=account_name,
+                name=account_name,
+                display_name=display_name or account_name,
                 github_name=github_name,
             ),  # type: ignore
         },

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -47,10 +47,11 @@ def warm_project(
         if project is None:
             logger.warning(f"Nothing to warm: {owner_name}/{project_name}")
             return {"project": f"{owner_name}/{project_name}", "found": False}
-        # A shared checkout carries the project's own credentials, so most
-        # projects need no user here at all. The owner is the fallback for a
-        # private project the GitHub App isn't installed on: there is no
-        # shared copy for those, so someone's own checkout has to stand in.
+        # A read-only checkout is shared, and carries the project's own
+        # credentials, so most projects need no user here at all. The owner
+        # is the fallback for a private project the GitHub App isn't
+        # installed on: there is no shared copy for those, so someone's own
+        # checkout has to stand in.
         user: User | None = None
         if not project.is_public:
             user = session.exec(
@@ -76,15 +77,15 @@ def warm_project(
         slug = f"{owner_name}/{project_name}".lower()
         warmed_key = cache.make_key("warmed", slug)
         try:
-            # The shared checkout, because that is the one readers land
-            # on: warming a single user's copy would leave everyone else to
+            # Read-only, so this warms the checkout readers land on:
+            # warming a single user's copy would leave everyone else to
             # clone it again for themselves.
             repo = get_repo(
                 project=project,
                 user=user,
                 session=session,
                 ttl=0,
-                shared_read=True,
+                read_only=True,
             )
             done.append("clone")
             sha = resolve_commit_sha(repo, None)

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -16,6 +16,7 @@ minutes and the threadpool is what serves requests.
 """
 
 import time
+from typing import Any, Callable
 
 from sqlmodel import Session, select
 
@@ -27,7 +28,7 @@ from app.models import Account, Project, User
 
 def warm_project(
     owner_name: str, project_name: str, force: bool = False
-) -> dict:
+) -> dict[str, Any]:
     """Refresh a project's clone and recompute what the project view reads.
 
     Returns a summary of what ran, for the worker log. Never raises: a warm
@@ -130,7 +131,9 @@ def warm_project(
     }
 
 
-def _steps():
+def _steps() -> list[
+    tuple[str, Callable[[Project, User | None, Session], None]]
+]:
     """The warm steps, in the order the project view needs them.
 
     Imported lazily and listed here rather than called inline so one failing
@@ -147,7 +150,9 @@ def _steps():
     """
     from app.api.routes.projects import core as routes
 
-    def pipeline(project, user, session):
+    def pipeline(
+        project: Project, user: User | None, session: Session
+    ) -> None:
         routes.get_project_pipeline(
             owner_name=project.owner_account_name,
             project_name=project.name,
@@ -156,7 +161,7 @@ def _steps():
             ref=None,
         )
 
-    def figures(project, user, session):
+    def figures(project: Project, user: User | None, session: Session) -> None:
         # Every argument is passed, including the ones with defaults: called
         # outside a request, a FastAPI ``Query(...)`` default arrives as the
         # Query object rather than its value, and a Query object is truthy.
@@ -173,7 +178,9 @@ def _steps():
             thumbnails=True,
         )
 
-    def references(project, user, session):
+    def references(
+        project: Project, user: User | None, session: Session
+    ) -> None:
         routes.get_project_references(
             owner_name=project.owner_account_name,
             project_name=project.name,
@@ -182,7 +189,9 @@ def _steps():
             ref=None,
         )
 
-    def questions(project, user, session):
+    def questions(
+        project: Project, user: User | None, session: Session
+    ) -> None:
         routes.get_project_questions(
             owner_name=project.owner_account_name,
             project_name=project.name,
@@ -191,7 +200,9 @@ def _steps():
             ref=None,
         )
 
-    def datasets(project, user, session):
+    def datasets(
+        project: Project, user: User | None, session: Session
+    ) -> None:
         routes.get_project_datasets(
             owner_name=project.owner_account_name,
             project_name=project.name,
@@ -200,7 +211,9 @@ def _steps():
             ref=None,
         )
 
-    def publications(project, user, session):
+    def publications(
+        project: Project, user: User | None, session: Session
+    ) -> None:
         routes.get_project_publications(
             owner_name=project.owner_account_name,
             project_name=project.name,

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -52,20 +52,15 @@ def warm_project(
         # credentials, so most projects need no user here at all. The owner
         # is the fallback for a private project the GitHub App isn't
         # installed on: there is no shared copy for those, so someone's own
-        # checkout has to stand in.
+        # checkout has to stand in. Not finding one is not a reason to stop
+        # -- an org account has no user behind it at all, and its projects
+        # warm perfectly well from the shared checkout. Whether this one can
+        # be read is settled by trying, below, rather than guessed at here.
         user: User | None = None
         if not project.is_public:
             user = session.exec(
                 select(User).where(User.id == project.owner_account.user_id)
             ).first()
-            if user is None:
-                logger.warning(
-                    f"No user to warm private {owner_name}/{project_name}"
-                )
-                return {
-                    "project": f"{owner_name}/{project_name}",
-                    "private_no_user": True,
-                }
         # The clone is what tells us which commit we would be warming, so
         # it happens here rather than as a step: everything after it is
         # derived from that commit and keyed by it, so if the last warm

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -47,10 +47,10 @@ def warm_project(
         if project is None:
             logger.warning(f"Nothing to warm: {owner_name}/{project_name}")
             return {"project": f"{owner_name}/{project_name}", "found": False}
-        # A private project can't be cloned anonymously, so warm it as its
-        # owner. The clone is per user, but everything computed from it is
-        # keyed by content or commit, so one pass fills the shared caches for
-        # everyone regardless of whose checkout produced it.
+        # A shared checkout carries the project's own credentials, so most
+        # projects need no user here at all. The owner is the fallback for a
+        # private project the GitHub App isn't installed on: there is no
+        # shared copy for those, so someone's own checkout has to stand in.
         user: User | None = None
         if not project.is_public:
             user = session.exec(
@@ -76,7 +76,16 @@ def warm_project(
         slug = f"{owner_name}/{project_name}".lower()
         warmed_key = cache.make_key("warmed", slug)
         try:
-            repo = get_repo(project=project, user=user, session=session, ttl=0)
+            # The shared checkout, because that is the one readers land
+            # on: warming a single user's copy would leave everyone else to
+            # clone it again for themselves.
+            repo = get_repo(
+                project=project,
+                user=user,
+                session=session,
+                ttl=0,
+                shared_read=True,
+            )
             done.append("clone")
             sha = resolve_commit_sha(repo, None)
         except Exception as e:

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -18,12 +18,12 @@ minutes and the threadpool is what serves requests.
 import time
 from typing import Any, Callable
 
-from sqlmodel import Session, select
+from sqlmodel import Session, col, select
 
 from app import cache
 from app.core import logger
 from app.db import engine
-from app.models import Account, Project, User
+from app.models import Account, Project, User, UserOrgMembership
 
 
 def warm_project(
@@ -48,14 +48,35 @@ def warm_project(
         if project is None:
             logger.warning(f"Nothing to warm: {owner_name}/{project_name}")
             return {"project": f"{owner_name}/{project_name}", "found": False}
-        # A shared checkout carries the project's own credentials, so only
-        # a private project the App isn't installed on needs a user, and an
-        # org has none. Whether it can be read is settled by trying below.
+        # The steps below go through the routes, which check access as
+        # somebody, so a private project needs a user even when the shared
+        # checkout could be read without one. An org account has no user of
+        # its own, so warm as one of its members -- any of them can read it.
         user: User | None = None
         if not project.is_public:
-            user = session.exec(
-                select(User).where(User.id == project.owner_account.user_id)
-            ).first()
+            account = project.owner_account
+            if account.user_id is not None:
+                user = session.exec(
+                    select(User).where(User.id == account.user_id)
+                ).first()
+            elif account.org_id is not None:
+                user = session.exec(
+                    select(User)
+                    .join(
+                        UserOrgMembership,
+                        UserOrgMembership.user_id == User.id,  # type: ignore[arg-type]
+                    )
+                    .where(UserOrgMembership.org_id == account.org_id)
+                    .order_by(col(UserOrgMembership.role_id).desc())
+                ).first()
+            if user is None:
+                logger.warning(
+                    f"No user to warm private {owner_name}/{project_name}"
+                )
+                return {
+                    "project": f"{owner_name}/{project_name}",
+                    "private_no_user": True,
+                }
         # The clone is what tells us which commit we would be warming, so
         # it happens here rather than as a step: everything after it is
         # derived from that commit and keyed by it, so if the last warm

--- a/hub/backend/app/warm.py
+++ b/hub/backend/app/warm.py
@@ -48,14 +48,9 @@ def warm_project(
         if project is None:
             logger.warning(f"Nothing to warm: {owner_name}/{project_name}")
             return {"project": f"{owner_name}/{project_name}", "found": False}
-        # A read-only checkout is shared, and carries the project's own
-        # credentials, so most projects need no user here at all. The owner
-        # is the fallback for a private project the GitHub App isn't
-        # installed on: there is no shared copy for those, so someone's own
-        # checkout has to stand in. Not finding one is not a reason to stop
-        # -- an org account has no user behind it at all, and its projects
-        # warm perfectly well from the shared checkout. Whether this one can
-        # be read is settled by trying, below, rather than guessed at here.
+        # A shared checkout carries the project's own credentials, so only
+        # a private project the App isn't installed on needs a user, and an
+        # org has none. Whether it can be read is settled by trying below.
         user: User | None = None
         if not project.is_public:
             user = session.exec(
@@ -73,9 +68,7 @@ def warm_project(
         slug = f"{owner_name}/{project_name}".lower()
         warmed_key = cache.make_key("warmed", slug)
         try:
-            # Read-only, so this warms the checkout readers land on:
-            # warming a single user's copy would leave everyone else to
-            # clone it again for themselves.
+            # Read-only, so this warms the checkout readers land on.
             repo = get_repo(
                 project=project,
                 user=user,

--- a/hub/docker-compose.override.yml
+++ b/hub/docker-compose.override.yml
@@ -92,6 +92,31 @@ services:
       # without rebuilding. Resolved by the Makefile.
       HUB_VERSION: ${HUB_VERSION-}
 
+  # Without this the worker runs whatever was baked into the image while
+  # everything else runs the mounted source, so a signature change breaks
+  # every job until someone rebuilds.
+  worker:
+    restart: "no"
+    env_file:
+      - .env
+    volumes:
+      - ../:/app
+      - /app/.venv
+    build:
+      context: ..
+      dockerfile: hub/backend/Dockerfile
+      args:
+        INSTALL_DEV: ${INSTALL_DEV-true}
+    # RQ has no --reload of its own, so watchfiles (already here, via
+    # `fastapi run --reload`) restarts it when the source it runs changes.
+    command:
+      - watchfiles
+      - --filter
+      - python
+      - "rq worker --url ${REDIS_URL:-redis://cache:6379/0} warm"
+      - app
+      - ../../calkit
+
   backend-dvc:
     restart: "no"
     env_file:

--- a/hub/docker-compose.override.yml
+++ b/hub/docker-compose.override.yml
@@ -158,12 +158,17 @@ services:
       - "5173:5173"
     volumes:
       - ./frontend/:/app
-      # Do not mount node_modules from host, use container's node_modules
-      - /app/node_modules
+      # Do not mount node_modules from host, use container's node_modules.
+      # Named rather than anonymous so `docker compose run` writes into the
+      # same one `up` reads from (see the end-to-end job in test-hub.yml).
+      - frontend-node-modules:/app/node_modules
     command:
       - sh
       - -c
       - "npm install && npm run dev"
+
+volumes:
+  frontend-node-modules:
 
 networks:
   traefik-public:

--- a/hub/docker-compose.yml
+++ b/hub/docker-compose.yml
@@ -231,7 +231,9 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      - REDIS_ADDR=redis://cache:6379
+      # The same URL the app and the worker use, so the exporter can never
+      # end up watching a different Redis than the one being written to.
+      - REDIS_ADDR=${REDIS_URL:-redis://cache:6379/0}
 
   # Reads the queue's state out of the cache and offers it to Prometheus.
   # A separate process rather than a route on the API: the queue is one
@@ -245,9 +247,9 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      - RQ_REDIS_HOST=cache
-      - RQ_REDIS_PORT=6379
-      - RQ_REDIS_DB=0
+      # As above: one URL for the queue, whoever is reading or writing it.
+      # RQ_REDIS_URL takes precedence over the host/port/db variables.
+      - RQ_REDIS_URL=${REDIS_URL:-redis://cache:6379/0}
 
   # Runs the work a push makes necessary -- see app/warm.py -- off the
   # API's threadpool, which is what serves requests.

--- a/hub/docker-compose.yml
+++ b/hub/docker-compose.yml
@@ -231,8 +231,8 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      # The same URL the app and the worker use, so the exporter can never
-      # end up watching a different Redis than the one being written to.
+      # The same URL the app and worker use, so the exporter can't end up
+      # watching a different Redis.
       - REDIS_ADDR=${REDIS_URL:-redis://cache:6379/0}
 
   # Reads the queue's state out of the cache and offers it to Prometheus.
@@ -247,8 +247,7 @@ services:
         condition: service_healthy
         restart: true
     environment:
-      # As above: one URL for the queue, whoever is reading or writing it.
-      # RQ_REDIS_URL takes precedence over the host/port/db variables.
+      # As above; RQ_REDIS_URL wins over the host/port/db variables.
       - RQ_REDIS_URL=${REDIS_URL:-redis://cache:6379/0}
 
   # Runs the work a push makes necessary -- see app/warm.py -- off the

--- a/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
+++ b/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
@@ -396,14 +396,26 @@ function PdfViewerInner({
   // giving up: otherwise the first paint keeps PDF.js's own default scale
   // until PdfHighlighter's ResizeObserver corrects it 500 ms later, which
   // reads as the page loading zoomed in and then jumping.
+  //
+  // Keyed on `url` as well: PdfHighlighter is keyed on it too, so every new
+  // document builds a fresh viewer that needs the scale applied again.
+  // Without it only the very first document opened would avoid the jump.
   useEffect(() => {
     if (pagedNav) return
+    // A deliberate trigger rather than a value we read, as with
+    // highlightsKey above; referencing it keeps it a real dependency.
+    void url
     let raf: number | null = null
     const deadline = performance.now() + 5000
     const apply = () => {
       raf = null
       const viewer = highlighterRef.current?.viewer
-      if (viewer) {
+      // Not just "the viewer exists": setting currentScaleValue before
+      // PdfHighlighter has called setDocument on it does nothing at all,
+      // and then the 500 ms correction is the only thing that ever applies
+      // the scale. Which of those wins is a race, so this waits for the
+      // document rather than for the object that will hold it.
+      if (viewer?.pdfDocument) {
         viewer.currentScaleValue = scaleValue
         return
       }
@@ -413,36 +425,7 @@ function PdfViewerInner({
     return () => {
       if (raf !== null) cancelAnimationFrame(raf)
     }
-  }, [scaleValue, pagedNav])
-
-  // Re-apply the scale as soon as our own container changes width, rather
-  // than waiting for PdfHighlighter's 500 ms-debounced observer. A viewer
-  // embedded in a page that reflows while it loads -- the project showcase,
-  // where figures and notebooks land above it -- otherwise renders at a
-  // width the page no longer has, then visibly corrects itself.
-  useEffect(() => {
-    if (pagedNav) return
-    const root = containerRef.current
-    if (!root || typeof ResizeObserver === "undefined") return
-    let lastWidth = root.clientWidth
-    let raf: number | null = null
-    const observer = new ResizeObserver(() => {
-      if (raf !== null) return
-      raf = requestAnimationFrame(() => {
-        raf = null
-        const width = root.clientWidth
-        if (width === lastWidth || width === 0) return
-        lastWidth = width
-        const viewer = highlighterRef.current?.viewer
-        if (viewer) viewer.currentScaleValue = scaleValue
-      })
-    })
-    observer.observe(root)
-    return () => {
-      observer.disconnect()
-      if (raf !== null) cancelAnimationFrame(raf)
-    }
-  }, [scaleValue, pagedNav, containerRef])
+  }, [scaleValue, pagedNav, url])
 
   // Load the section outline (bookmarks) once per document.
   useEffect(() => {

--- a/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
+++ b/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
@@ -391,10 +391,28 @@ function PdfViewerInner({
   // re-applies pdfScaleValue on initial load or on a container resize (not on a
   // prop change), so without this the toolbar zoom wouldn't take effect until
   // the next layout change.
+  //
+  // The viewer doesn't exist yet on mount, so this waits for it rather than
+  // giving up: otherwise the first paint keeps PDF.js's own default scale
+  // until PdfHighlighter's ResizeObserver corrects it 500 ms later, which
+  // reads as the page loading zoomed in and then jumping.
   useEffect(() => {
     if (pagedNav) return
-    const viewer = highlighterRef.current?.viewer
-    if (viewer) viewer.currentScaleValue = scaleValue
+    let raf: number | null = null
+    const deadline = performance.now() + 5000
+    const apply = () => {
+      raf = null
+      const viewer = highlighterRef.current?.viewer
+      if (viewer) {
+        viewer.currentScaleValue = scaleValue
+        return
+      }
+      if (performance.now() < deadline) raf = requestAnimationFrame(apply)
+    }
+    apply()
+    return () => {
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
   }, [scaleValue, pagedNav])
 
   // Load the section outline (bookmarks) once per document.

--- a/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
+++ b/hub/frontend/src/components/Common/PdfDocumentViewer.tsx
@@ -415,6 +415,35 @@ function PdfViewerInner({
     }
   }, [scaleValue, pagedNav])
 
+  // Re-apply the scale as soon as our own container changes width, rather
+  // than waiting for PdfHighlighter's 500 ms-debounced observer. A viewer
+  // embedded in a page that reflows while it loads -- the project showcase,
+  // where figures and notebooks land above it -- otherwise renders at a
+  // width the page no longer has, then visibly corrects itself.
+  useEffect(() => {
+    if (pagedNav) return
+    const root = containerRef.current
+    if (!root || typeof ResizeObserver === "undefined") return
+    let lastWidth = root.clientWidth
+    let raf: number | null = null
+    const observer = new ResizeObserver(() => {
+      if (raf !== null) return
+      raf = requestAnimationFrame(() => {
+        raf = null
+        const width = root.clientWidth
+        if (width === lastWidth || width === 0) return
+        lastWidth = width
+        const viewer = highlighterRef.current?.viewer
+        if (viewer) viewer.currentScaleValue = scaleValue
+      })
+    })
+    observer.observe(root)
+    return () => {
+      observer.disconnect()
+      if (raf !== null) cancelAnimationFrame(raf)
+    }
+  }, [scaleValue, pagedNav, containerRef])
+
   // Load the section outline (bookmarks) once per document.
   useEffect(() => {
     let cancelled = false

--- a/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/figures.tsx
+++ b/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/figures.tsx
@@ -76,16 +76,30 @@ const FIGURES_PER_PAGE = 20
 // At this size the chrome is what has to go -- the default margins alone are
 // most of a 140px canvas, before a title or tick labels. What makes a plot
 // recognisable that small is the shape of its traces.
-const thumbnailLayout = (layout: Record<string, unknown>) => ({
-  ...layout,
-  title: undefined,
-  showlegend: false,
-  margin: { l: 2, r: 2, t: 2, b: 2 },
-  xaxis: { ...(layout.xaxis as object), visible: false, title: undefined },
-  yaxis: { ...(layout.yaxis as object), visible: false, title: undefined },
-  paper_bgcolor: "rgba(0,0,0,0)",
-  plot_bgcolor: "rgba(0,0,0,0)",
-})
+const thumbnailLayout = (layout: Record<string, unknown>) => {
+  // Every axis, not just the first: a figure with stacked subplots carries
+  // xaxis2, yaxis3 and so on, and each keeps its own ticks and title. Left
+  // in, they overlap the traces and each other at this size.
+  const hidden = { visible: false, title: undefined }
+  const axes: Record<string, unknown> = { xaxis: hidden, yaxis: hidden }
+  for (const key of Object.keys(layout)) {
+    if (/^[xy]axis\d*$/.test(key)) {
+      axes[key] = { ...(layout[key] as object), ...hidden }
+    }
+  }
+  return {
+    ...layout,
+    title: undefined,
+    showlegend: false,
+    margin: { l: 2, r: 2, t: 2, b: 2 },
+    ...axes,
+    // Subplot titles are annotations rather than titles, so they survive
+    // everything above and land on top of what they label.
+    annotations: [],
+    paper_bgcolor: "rgba(0,0,0,0)",
+    plot_bgcolor: "rgba(0,0,0,0)",
+  }
+}
 
 function PlotlyThumbnail({ figure }: { figure: Figure }) {
   const [src, setSrc] = useState<string | null>(null)

--- a/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/publications.tsx
+++ b/hub/frontend/src/routes/_layout/$accountName/$projectName/_layout/publications.tsx
@@ -398,6 +398,18 @@ function Publications() {
     publicationsRequest.data?.find((p) => p.path === selectedPath) ??
     publicationsRequest.data?.[0]
 
+  // Landing without a path shows the first publication, so put it in the URL
+  // to match: otherwise a link copied from here points at "whichever is
+  // first", which is not necessarily what the sender was looking at.
+  // Replaced rather than pushed, so arriving doesn't cost a back step.
+  useEffect(() => {
+    if (selectedPath || !selectedPub?.path) return
+    navigate({
+      search: (prev) => ({ ...prev, path: selectedPub.path }),
+      replace: true,
+    })
+  }, [selectedPath, selectedPub?.path, navigate])
+
   // Arriving from a question's evidence (or right after committing an edit)
   // can transiently return an empty list; if we expected a specific
   // publication (path in the URL) but got none, refetch once so it appears

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,15 @@ show_error_codes = true
 
 # Third-party modules that ship no type stubs.
 [[tool.mypy.overrides]]
-module = ["sqlitedict", "networkx", "yaml", "dvc", "dvc.*", "requests"]
+module = [
+    "sqlitedict",
+    "networkx",
+    "yaml",
+    "dvc",
+    "dvc.*",
+    "requests",
+    "pypdfium2",
+]
 ignore_missing_imports = true
 
 # jsonschema's stubs come from the types-jsonschema dev dependency, which


### PR DESCRIPTION
## TODO

- [x] Fix first figures page load latency
- [x] Create a pre-commit hook in the read-only clones to error if a commit is attempted
- [x] Make absolute sure read-only clones have no GitHub write access credentials left over in them that could allow unauthorized access