### PR TITLE
Push annotated tags along with commits

### DIFF
--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1672,17 +1672,13 @@ def push(
             git_cmd = ["git", "push"]
             if not no_recursive and "--recurse-submodules" not in git_args:
                 git_cmd.append("--recurse-submodules=on-demand")
-            # Annotated tags travel with the commits they mark. A plain
-            # `git push` leaves them behind, so a project that tags results
-            # ends up with tags that exist only on the machine that made
-            # them, and anyone cloning gets the history without the labels.
-            # `--follow-tags` is the conservative form: only annotated tags
-            # reachable from what is being pushed, so unannotated scratch
-            # tags and tags on other branches stay local.
-            if not any(
-                arg.startswith(("--follow-tags", "--no-follow-tags", "--tags"))
-                for arg in git_args
-            ):
+            # A plain `git push` leaves tags behind, so annotated tags end
+            # up only on the machine that made them
+            if not {
+                "--follow-tags",
+                "--no-follow-tags",
+                "--tags",
+            }.intersection(git_args):
                 git_cmd.append("--follow-tags")
             subprocess.check_call(git_cmd + git_args)
         except subprocess.CalledProcessError:

--- a/calkit/cli/main/core.py
+++ b/calkit/cli/main/core.py
@@ -1672,6 +1672,18 @@ def push(
             git_cmd = ["git", "push"]
             if not no_recursive and "--recurse-submodules" not in git_args:
                 git_cmd.append("--recurse-submodules=on-demand")
+            # Annotated tags travel with the commits they mark. A plain
+            # `git push` leaves them behind, so a project that tags results
+            # ends up with tags that exist only on the machine that made
+            # them, and anyone cloning gets the history without the labels.
+            # `--follow-tags` is the conservative form: only annotated tags
+            # reachable from what is being pushed, so unannotated scratch
+            # tags and tags on other branches stay local.
+            if not any(
+                arg.startswith(("--follow-tags", "--no-follow-tags", "--tags"))
+                for arg in git_args
+            ):
+                git_cmd.append("--follow-tags")
             subprocess.check_call(git_cmd + git_args)
         except subprocess.CalledProcessError:
             raise_error("Git push failed")

--- a/calkit/tests/cli/main/test_core.py
+++ b/calkit/tests/cli/main/test_core.py
@@ -2784,3 +2784,43 @@ def test_push_reports_what_was_pushed(monkeypatch, tmp_dir):
     assert sent[-1]["targets"] == ["dvc"]
     cli_core._tell_hub_we_pushed(["dvc", "docker", "git"], [])
     assert sent[-1]["targets"] == ["dvc", "docker", "git"]
+
+
+def test_push_carries_annotated_tags(tmp_dir):
+    """Annotated tags should reach the remote along with their commits.
+
+    A plain ``git push`` leaves tags behind, so a project that tags its
+    results ends up with labels that exist only on the machine that made
+    them.
+    """
+    remote = os.path.join(tmp_dir, "remote.git")
+    subprocess.check_call(["git", "init", "--bare", "-q", remote])
+    work = os.path.join(tmp_dir, "work")
+    os.makedirs(work)
+    os.chdir(work)
+    subprocess.check_call(["git", "init", "-q"])
+    subprocess.check_call(["git", "remote", "add", "origin", remote])
+    # ``calkit init`` commits what it creates, so there is a commit to tag
+    subprocess.check_call(["calkit", "init"])
+    subprocess.check_call(["git", "tag", "-a", "v0.1.0", "-m", "First"])
+    # An unannotated tag must stay local: --follow-tags is deliberately the
+    # conservative form, so scratch tags do not get published by accident
+    subprocess.check_call(["git", "tag", "scratch"])
+    subprocess.check_call(
+        [
+            "calkit",
+            "push",
+            "git",
+            "--git-arg",
+            "-u",
+            "--git-arg",
+            "origin",
+            "--git-arg",
+            "HEAD",
+        ]
+    )
+    tags = subprocess.check_output(
+        ["git", "ls-remote", "--tags", remote], text=True
+    )
+    assert "v0.1.0" in tags
+    assert "scratch" not in tags


### PR DESCRIPTION
From Claude:

## Problem

`calkit push` runs a plain `git push`, which does not carry tags. `calkit save` delegates to `push`, so it has the same gap.

The effect is quiet: the push succeeds, `git status` is clean, and the local clone looks complete because the tags are right there. It only shows up for someone else — or on a fresh clone — where the history arrives without the labels.

That matters for a project that tags results. In the one I hit this on, experiment tags are how each row of a results table points at the commit that produced it, and several existed only on the machine that made them. I found it by checking `git ls-remote --tags` after a `calkit push` that reported success.

## Change

Add `--follow-tags` to the `git push` in `push()`.

`--follow-tags` is the conservative form: it sends **annotated** tags reachable from the refs being pushed. Unannotated scratch tags stay local, and so do tags on branches that are not being pushed — so this does not turn a push into a bulk tag publish.

It is skipped when the caller has already said something about tags via `--git-arg`, so `--git-arg --tags` and `--git-arg --no-follow-tags` both keep working.

## Test

`test_push_carries_annotated_tags` pushes to a real bare remote and asserts the annotated tag arrives and an unannotated one does not. It fails without the change and passes with it — I checked by stashing the fix and re-running.